### PR TITLE
Add remove participant use case

### DIFF
--- a/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetDto.ts
+++ b/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetDto.ts
@@ -1,0 +1,5 @@
+export interface RemoveParticipantFromBudgetDto {
+  userId: string;
+  budgetId: string;
+  participantId: string;
+}

--- a/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.spec.ts
+++ b/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.spec.ts
@@ -1,0 +1,259 @@
+import { Budget } from '@domain/aggregates/budget/budget-entity/Budget';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { Either } from '@either';
+
+import { CannotRemoveOwnerFromParticipantsError } from '@domain/shared/errors/CannotRemoveOwnerFromParticipantsError';
+import { BudgetNotFoundError } from '../../../shared/errors/BudgetNotFoundError';
+import { BudgetPersistenceFailedError } from '../../../shared/errors/BudgetPersistenceFailedError';
+import { BudgetRepositoryError } from '../../../shared/errors/BudgetRepositoryError';
+import { BudgetUpdateFailedError } from '../../../shared/errors/BudgetUpdateFailedError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetBudgetRepositoryStub } from '../../../shared/tests/stubs/GetBudgetRepositoryStub';
+import { SaveBudgetRepositoryStub } from '../../../shared/tests/stubs/SaveBudgetRepositoryStub';
+import { RemoveParticipantFromBudgetDto } from './RemoveParticipantFromBudgetDto';
+import { RemoveParticipantFromBudgetUseCase } from './RemoveParticipantFromBudgetUseCase';
+
+describe('RemoveParticipantFromBudgetUseCase', () => {
+  let useCase: RemoveParticipantFromBudgetUseCase;
+  let getBudgetRepositoryStub: GetBudgetRepositoryStub;
+  let saveBudgetRepositoryStub: SaveBudgetRepositoryStub;
+  let budgetAuthorizationServiceStub: BudgetAuthorizationServiceStub;
+  let eventPublisherStub: EventPublisherStub;
+  let validBudget: Budget;
+  const userId = EntityId.create().value!.id;
+  const participantId = EntityId.create().value!.id;
+
+  beforeEach(() => {
+    getBudgetRepositoryStub = new GetBudgetRepositoryStub();
+    saveBudgetRepositoryStub = new SaveBudgetRepositoryStub();
+    budgetAuthorizationServiceStub = new BudgetAuthorizationServiceStub();
+    eventPublisherStub = new EventPublisherStub();
+    useCase = new RemoveParticipantFromBudgetUseCase(
+      getBudgetRepositoryStub,
+      saveBudgetRepositoryStub,
+      budgetAuthorizationServiceStub,
+      eventPublisherStub,
+    );
+
+    const budgetResult = Budget.create({
+      name: 'Test Budget',
+      ownerId: userId,
+      participantIds: [participantId],
+    });
+
+    if (budgetResult.hasError) {
+      throw new Error(
+        `Failed to create budget: ${budgetResult.errors.map((e) => e.message).join(', ')}`,
+      );
+    }
+
+    validBudget = budgetResult.data!;
+    validBudget.clearEvents();
+    getBudgetRepositoryStub.mockBudget = validBudget;
+    budgetAuthorizationServiceStub.mockHasAccess = true;
+  });
+
+  describe('execute', () => {
+    it('should remove participant successfully when user has permission', async () => {
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+      expect(result.hasError).toBe(false);
+      expect(result.data!.id).toBe(validBudget.id);
+    });
+
+    it('should fail when user has no permission', async () => {
+      budgetAuthorizationServiceStub.mockHasAccess = false;
+
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId: 'unauthorized-user',
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.hasData).toBe(false);
+      expect(result.errors[0]).toEqual(new InsufficientPermissionsError());
+    });
+
+    it('should fail when budget does not exist', async () => {
+      getBudgetRepositoryStub.shouldReturnNull = true;
+
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: 'non-existent-id',
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.hasData).toBe(false);
+      expect(result.errors[0]).toEqual(new BudgetNotFoundError());
+    });
+
+    it('should fail when removing owner', async () => {
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId: userId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.hasData).toBe(false);
+      expect(result.errors[0]).toBeInstanceOf(BudgetUpdateFailedError);
+      expect(result.errors[0]).toEqual(
+        new BudgetUpdateFailedError(new CannotRemoveOwnerFromParticipantsError().message),
+      );
+    });
+
+    it('should fail when participantId is invalid', async () => {
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId: 'invalid-id',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.hasData).toBe(false);
+      expect(result.errors[0]).toBeInstanceOf(BudgetUpdateFailedError);
+    });
+
+    it('should fail when getBudget repository returns error', async () => {
+      getBudgetRepositoryStub.shouldFail = true;
+
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.hasData).toBe(false);
+      expect(result.errors[0]).toEqual(new BudgetRepositoryError());
+    });
+
+    it('should fail when saveBudget repository returns error', async () => {
+      saveBudgetRepositoryStub.shouldFail = true;
+
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.hasData).toBe(false);
+      expect(result.errors[0]).toEqual(new BudgetPersistenceFailedError());
+    });
+
+    it('should fail when authorization service returns error', async () => {
+      const repositoryError = new RepositoryError('Authorization service failed');
+      jest
+        .spyOn(budgetAuthorizationServiceStub, 'canAccessBudget')
+        .mockResolvedValueOnce(Either.errors([repositoryError]));
+
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.hasData).toBe(false);
+    });
+
+    it('should call authorization service with correct parameters', async () => {
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId: 'test-user',
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      await useCase.execute(dto);
+
+      expect(budgetAuthorizationServiceStub.canAccessBudgetCalls).toHaveLength(1);
+      expect(budgetAuthorizationServiceStub.canAccessBudgetCalls[0]).toEqual({
+        userId: 'test-user',
+        budgetId: validBudget.id,
+      });
+    });
+
+    it('should publish events after successful removal', async () => {
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+      const events = validBudget.getEvents();
+      if (events.length > 0) {
+        expect(eventPublisherStub.publishManyCalls).toHaveLength(1);
+        expect(eventPublisherStub.publishManyCalls[0]).toHaveLength(events.length);
+      } else {
+        expect(eventPublisherStub.publishManyCalls).toHaveLength(0);
+      }
+    });
+
+    it('should handle event publishing errors gracefully', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      jest
+        .spyOn(eventPublisherStub, 'publishMany')
+        .mockRejectedValueOnce(new Error('Event publishing failed'));
+
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should clear events after successful publishing', async () => {
+      const clearEventsSpy = jest.spyOn(validBudget, 'clearEvents');
+
+      const dto: RemoveParticipantFromBudgetDto = {
+        userId,
+        budgetId: validBudget.id,
+        participantId,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+      const events = validBudget.getEvents();
+      if (events.length > 0) {
+        expect(clearEventsSpy).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+});

--- a/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.ts
+++ b/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.ts
@@ -1,0 +1,79 @@
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IGetBudgetRepository } from '../../../contracts/repositories/budget/IGetBudgetRepository';
+import { ISaveBudgetRepository } from '../../../contracts/repositories/budget/ISaveBudgetRepository';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { BudgetNotFoundError } from '../../../shared/errors/BudgetNotFoundError';
+import { BudgetRepositoryError } from '../../../shared/errors/BudgetRepositoryError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+import { BudgetPersistenceFailedError } from '../../../shared/errors/BudgetPersistenceFailedError';
+import { BudgetUpdateFailedError } from '../../../shared/errors/BudgetUpdateFailedError';
+import { RemoveParticipantFromBudgetDto } from './RemoveParticipantFromBudgetDto';
+
+export class RemoveParticipantFromBudgetUseCase
+  implements IUseCase<RemoveParticipantFromBudgetDto>
+{
+  constructor(
+    private getBudgetRepository: IGetBudgetRepository,
+    private saveBudgetRepository: ISaveBudgetRepository,
+    private budgetAuthorizationService: IBudgetAuthorizationService,
+    private eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(
+    dto: RemoveParticipantFromBudgetDto,
+  ): Promise<Either<ApplicationError, UseCaseResponse>> {
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      dto.budgetId,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors<ApplicationError, UseCaseResponse>(authResult.errors);
+    }
+
+    if (!authResult.data) {
+      return Either.error(new InsufficientPermissionsError());
+    }
+
+    const budgetResult = await this.getBudgetRepository.execute(dto.budgetId);
+
+    if (budgetResult.hasError) {
+      return Either.error(new BudgetRepositoryError());
+    }
+
+    if (!budgetResult.data) {
+      return Either.error(new BudgetNotFoundError());
+    }
+
+    const budget = budgetResult.data;
+
+    const removeResult = budget.removeParticipant(dto.participantId);
+
+    if (removeResult.hasError) {
+      const errorMessage = removeResult.errors.map((e) => e.message).join('; ');
+      return Either.error(new BudgetUpdateFailedError(errorMessage));
+    }
+
+    const saveResult = await this.saveBudgetRepository.execute(budget);
+
+    if (saveResult.hasError) {
+      return Either.error(new BudgetPersistenceFailedError());
+    }
+
+    const events = budget.getEvents();
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        budget.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success({ id: budget.id });
+  }
+}


### PR DESCRIPTION
## Summary
- implement RemoveParticipantFromBudget use case
- add DTO for removing participant
- cover edge cases with unit tests

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c5a7f0cc8323bd9ab4ecaa9a6000