### PR TITLE
Implement transfer between accounts use case

### DIFF
--- a/src/application/shared/errors/AccountsFromDifferentBudgetsError.ts
+++ b/src/application/shared/errors/AccountsFromDifferentBudgetsError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class AccountsFromDifferentBudgetsError extends ApplicationError {
+  constructor() {
+    super('Accounts belong to different budgets');
+  }
+}

--- a/src/application/shared/errors/InvalidTransferAmountError.ts
+++ b/src/application/shared/errors/InvalidTransferAmountError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class InvalidTransferAmountError extends ApplicationError {
+  constructor() {
+    super('Transfer amount must be greater than zero');
+  }
+}

--- a/src/application/shared/errors/SameAccountTransferError.ts
+++ b/src/application/shared/errors/SameAccountTransferError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class SameAccountTransferError extends ApplicationError {
+  constructor() {
+    super('Cannot transfer to the same account');
+  }
+}

--- a/src/application/shared/errors/TransferTransactionCreationFailedError.ts
+++ b/src/application/shared/errors/TransferTransactionCreationFailedError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class TransferTransactionCreationFailedError extends ApplicationError {
+  constructor(reason: string) {
+    super(`Transfer transaction creation failed: ${reason}`);
+  }
+}

--- a/src/application/use-cases/account/transfer-between-accounts/TransferBetweenAccountsDto.ts
+++ b/src/application/use-cases/account/transfer-between-accounts/TransferBetweenAccountsDto.ts
@@ -1,0 +1,7 @@
+export interface TransferBetweenAccountsDto {
+  userId: string;
+  fromAccountId: string;
+  toAccountId: string;
+  amount: number;
+  description?: string;
+}

--- a/src/application/use-cases/account/transfer-between-accounts/TransferBetweenAccountsUseCase.spec.ts
+++ b/src/application/use-cases/account/transfer-between-accounts/TransferBetweenAccountsUseCase.spec.ts
@@ -1,0 +1,370 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { AccountTypeEnum } from '@domain/aggregates/account/value-objects/account-type/AccountType';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { InvalidTransactionDescriptionError } from '@domain/aggregates/transaction/errors/InvalidTransactionDescriptionError';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { Either } from '@either';
+
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { AccountsFromDifferentBudgetsError } from '../../../shared/errors/AccountsFromDifferentBudgetsError';
+import { InvalidTransferAmountError } from '../../../shared/errors/InvalidTransferAmountError';
+import { SameAccountTransferError } from '../../../shared/errors/SameAccountTransferError';
+import { TransferTransactionCreationFailedError } from '../../../shared/errors/TransferTransactionCreationFailedError';
+import { AddTransactionRepositoryStub } from '../../../shared/tests/stubs/AddTransactionRepositoryStub';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { TransferBetweenAccountsDto } from './TransferBetweenAccountsDto';
+process.env.TRANSFER_CATEGORY_ID = EntityId.create().value!.id;
+import { TransferBetweenAccountsUseCase } from './TransferBetweenAccountsUseCase';
+
+const createAccounts = (budgetId: string) => {
+  const fromResult = Account.create({
+    name: 'Conta Origem',
+    type: AccountTypeEnum.CHECKING_ACCOUNT,
+    budgetId,
+    initialBalance: 1000,
+  });
+  const toResult = Account.create({
+    name: 'Conta Destino',
+    type: AccountTypeEnum.SAVINGS_ACCOUNT,
+    budgetId,
+    initialBalance: 500,
+  });
+  if (fromResult.hasError || toResult.hasError) {
+    throw new Error('Failed to create accounts for tests');
+  }
+  return { from: fromResult.data!, to: toResult.data! };
+};
+
+describe('TransferBetweenAccountsUseCase', () => {
+  let useCase: TransferBetweenAccountsUseCase;
+  let getAccountRepositoryStub: GetAccountRepositoryStub;
+  let addTransactionRepositoryStub: AddTransactionRepositoryStub;
+  let budgetAuthorizationServiceStub: BudgetAuthorizationServiceStub;
+  let eventPublisherStub: EventPublisherStub;
+  let fromAccount: Account;
+  let toAccount: Account;
+  const userId = EntityId.create().value!.id;
+  const budgetId = EntityId.create().value!.id;
+
+  beforeEach(() => {
+    getAccountRepositoryStub = new GetAccountRepositoryStub();
+    addTransactionRepositoryStub = new AddTransactionRepositoryStub();
+    budgetAuthorizationServiceStub = new BudgetAuthorizationServiceStub();
+    eventPublisherStub = new EventPublisherStub();
+    useCase = new TransferBetweenAccountsUseCase(
+      getAccountRepositoryStub,
+      addTransactionRepositoryStub,
+      budgetAuthorizationServiceStub,
+      eventPublisherStub,
+    );
+
+    const accounts = createAccounts(budgetId);
+    fromAccount = accounts.from;
+    toAccount = accounts.to;
+  });
+
+  const mockRepositorySuccess = () => {
+    jest
+      .spyOn(getAccountRepositoryStub, 'execute')
+      .mockImplementation(async (id: string) => {
+        getAccountRepositoryStub.executeCalls.push(id);
+        if (id === fromAccount.id) return Either.success(fromAccount);
+        if (id === toAccount.id) return Either.success(toAccount);
+        return Either.success(null);
+      });
+  };
+
+  describe('execute', () => {
+    it('should transfer successfully between accounts of the same budget', async () => {
+      mockRepositorySuccess();
+
+      const spyAdd = jest.spyOn(addTransactionRepositoryStub, 'execute');
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 200,
+        description: 'Pagamento',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+      expect(spyAdd).toHaveBeenCalledTimes(2);
+      expect(getAccountRepositoryStub.executeCalls).toEqual([
+        fromAccount.id,
+        toAccount.id,
+      ]);
+      expect(eventPublisherStub.publishManyCalls.length).toBe(1);
+      expect(result.data!.id).toBeDefined();
+    });
+
+    it('should return error when origin account not found', async () => {
+      jest
+        .spyOn(getAccountRepositoryStub, 'execute')
+        .mockImplementation(async (id: string) => {
+          getAccountRepositoryStub.executeCalls.push(id);
+          if (id === fromAccount.id) return Either.success(null);
+          return Either.success(toAccount);
+        });
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new AccountNotFoundError());
+    });
+
+    it('should return error when destination account not found', async () => {
+      jest
+        .spyOn(getAccountRepositoryStub, 'execute')
+        .mockImplementation(async (id: string) => {
+          getAccountRepositoryStub.executeCalls.push(id);
+          if (id === toAccount.id) return Either.success(null);
+          return Either.success(fromAccount);
+        });
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new AccountNotFoundError());
+    });
+
+    it('should return error when accounts belong to different budgets', async () => {
+      const otherBudgetAccounts = createAccounts(EntityId.create().value!.id);
+      toAccount = otherBudgetAccounts.to;
+      mockRepositorySuccess();
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new AccountsFromDifferentBudgetsError());
+    });
+
+    it('should return error when transferring to the same account', async () => {
+      jest
+        .spyOn(getAccountRepositoryStub, 'execute')
+        .mockResolvedValue(Either.success(fromAccount));
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: fromAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new SameAccountTransferError());
+    });
+
+    it('should return error when amount is invalid', async () => {
+      mockRepositorySuccess();
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 0,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new InvalidTransferAmountError());
+    });
+
+    it('should return error when user has no permission', async () => {
+      mockRepositorySuccess();
+      budgetAuthorizationServiceStub.mockHasAccess = false;
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new InsufficientPermissionsError());
+    });
+
+    it('should return error when creation of first transaction fails', async () => {
+      mockRepositorySuccess();
+      const createSpy = jest.spyOn(Transaction, 'create');
+      const executeSpy = jest.spyOn(addTransactionRepositoryStub, 'execute');
+      createSpy.mockReturnValueOnce(
+        Either.errors([new InvalidTransactionDescriptionError()]),
+      );
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(
+        TransferTransactionCreationFailedError,
+      );
+      expect(executeSpy).not.toHaveBeenCalled();
+      createSpy.mockRestore();
+    });
+
+    it('should return error when creation of second transaction fails', async () => {
+      mockRepositorySuccess();
+      const originalCreate = Transaction.create.bind(Transaction);
+      const createSpy = jest.spyOn(Transaction, 'create');
+      const executeSpy = jest.spyOn(addTransactionRepositoryStub, 'execute');
+      createSpy.mockImplementationOnce(originalCreate);
+      createSpy.mockImplementationOnce(() =>
+        Either.errors([new InvalidTransactionDescriptionError()]),
+      );
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(
+        TransferTransactionCreationFailedError,
+      );
+      expect(executeSpy).toHaveBeenCalledTimes(0);
+      createSpy.mockRestore();
+    });
+
+    it('should return error when authorization service fails', async () => {
+      mockRepositorySuccess();
+      jest
+        .spyOn(budgetAuthorizationServiceStub, 'canAccessBudget')
+        .mockResolvedValueOnce(
+          Either.errors([new RepositoryError('auth error')]),
+        );
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+    });
+
+    it('should return error when first transaction persistence fails', async () => {
+      mockRepositorySuccess();
+      jest
+        .spyOn(addTransactionRepositoryStub, 'execute')
+        .mockResolvedValueOnce(Either.error(new RepositoryError('fail')));
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new TransactionPersistenceFailedError());
+    });
+
+    it('should return error when second transaction persistence fails', async () => {
+      mockRepositorySuccess();
+      const executeSpy = jest
+        .spyOn(addTransactionRepositoryStub, 'execute')
+        .mockResolvedValueOnce(Either.success())
+        .mockResolvedValueOnce(Either.error(new RepositoryError('fail')));
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 100,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new TransactionPersistenceFailedError());
+      expect(executeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should publish events and clear them on success', async () => {
+      mockRepositorySuccess();
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 50,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+      if (result.hasData) {
+        const events = eventPublisherStub.publishManyCalls[0];
+        expect(events.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should handle errors during event publishing gracefully', async () => {
+      mockRepositorySuccess();
+      jest
+        .spyOn(eventPublisherStub, 'publishMany')
+        .mockRejectedValueOnce(new Error('fail'));
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const dto: TransferBetweenAccountsDto = {
+        userId,
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+        amount: 30,
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/application/use-cases/account/transfer-between-accounts/TransferBetweenAccountsUseCase.ts
+++ b/src/application/use-cases/account/transfer-between-accounts/TransferBetweenAccountsUseCase.ts
@@ -1,0 +1,195 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IAddTransactionRepository } from '../../../contracts/repositories/transaction/IAddTransactionRepository';
+import { IGetAccountRepository } from '../../../contracts/repositories/account/IGetAccountRepository';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { AccountsFromDifferentBudgetsError } from '../../../shared/errors/AccountsFromDifferentBudgetsError';
+import { InvalidTransferAmountError } from '../../../shared/errors/InvalidTransferAmountError';
+import { SameAccountTransferError } from '../../../shared/errors/SameAccountTransferError';
+import { TransferTransactionCreationFailedError } from '../../../shared/errors/TransferTransactionCreationFailedError';
+import { TransferBetweenAccountsDto } from './TransferBetweenAccountsDto';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+
+const TRANSFER_CATEGORY_ID = process.env.TRANSFER_CATEGORY_ID as string;
+
+export class TransferBetweenAccountsUseCase
+  implements IUseCase<TransferBetweenAccountsDto>
+{
+  constructor(
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly addTransactionRepository: IAddTransactionRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(
+    dto: TransferBetweenAccountsDto,
+  ): Promise<Either<DomainError | ApplicationError, UseCaseResponse>> {
+    const fromAccountResult = await this.getAccountRepository.execute(
+      dto.fromAccountId,
+    );
+
+    if (fromAccountResult.hasError) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new AccountRepositoryError(),
+      ]);
+    }
+
+    if (!fromAccountResult.data) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new AccountNotFoundError(),
+      ]);
+    }
+
+    const fromAccount = fromAccountResult.data as Account;
+
+    const toAccountResult = await this.getAccountRepository.execute(
+      dto.toAccountId,
+    );
+
+    if (toAccountResult.hasError) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new AccountRepositoryError(),
+      ]);
+    }
+
+    if (!toAccountResult.data) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new AccountNotFoundError(),
+      ]);
+    }
+
+    const toAccount = toAccountResult.data as Account;
+
+    if (fromAccount.budgetId !== toAccount.budgetId) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new AccountsFromDifferentBudgetsError(),
+      ]);
+    }
+
+    if (dto.fromAccountId === dto.toAccountId) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new SameAccountTransferError(),
+      ]);
+    }
+
+    if (dto.amount <= 0) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new InvalidTransferAmountError(),
+      ]);
+    }
+
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      fromAccount.budgetId!,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>(
+        authResult.errors,
+      );
+    }
+
+    if (!authResult.data) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new InsufficientPermissionsError(),
+      ]);
+    }
+
+    const outDescription = `Transferência para ${toAccount.name}`;
+    const inDescription = `Transferência de ${fromAccount.name}`;
+    const fullOutDescription = dto.description
+      ? `${outDescription} - ${dto.description}`
+      : outDescription;
+    const fullInDescription = dto.description
+      ? `${inDescription} - ${dto.description}`
+      : inDescription;
+
+    const outTransactionResult = Transaction.create({
+      description: fullOutDescription,
+      amount: dto.amount,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: new Date(),
+      categoryId: TRANSFER_CATEGORY_ID,
+      budgetId: fromAccount.budgetId!,
+      accountId: dto.fromAccountId,
+    });
+
+    if (outTransactionResult.hasError) {
+      const errorMessage = outTransactionResult.errors
+        .map((e) => e.message)
+        .join('; ');
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new TransferTransactionCreationFailedError(errorMessage),
+      ]);
+    }
+
+    const inTransactionResult = Transaction.create({
+      description: fullInDescription,
+      amount: dto.amount,
+      type: TransactionTypeEnum.INCOME,
+      transactionDate: new Date(),
+      categoryId: TRANSFER_CATEGORY_ID,
+      budgetId: toAccount.budgetId!,
+      accountId: dto.toAccountId,
+    });
+
+    if (inTransactionResult.hasError) {
+      const errorMessage = inTransactionResult.errors
+        .map((e) => e.message)
+        .join('; ');
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new TransferTransactionCreationFailedError(errorMessage),
+      ]);
+    }
+
+    const outTransaction = outTransactionResult.data!;
+    const inTransaction = inTransactionResult.data!;
+
+    const outTransactionSaveResult =
+      await this.addTransactionRepository.execute(outTransaction);
+
+    if (outTransactionSaveResult.hasError) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new TransactionPersistenceFailedError(),
+      ]);
+    }
+
+    const inTransactionSaveResult =
+      await this.addTransactionRepository.execute(inTransaction);
+
+    if (inTransactionSaveResult.hasError) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new TransactionPersistenceFailedError(),
+      ]);
+    }
+
+    const events = [
+      ...outTransaction.getEvents(),
+      ...inTransaction.getEvents(),
+    ];
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        outTransaction.clearEvents();
+        inTransaction.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success<DomainError | ApplicationError, UseCaseResponse>({
+      id: outTransaction.id,
+    });
+  }
+}

--- a/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.spec.ts
+++ b/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.spec.ts
@@ -116,7 +116,9 @@ describe('RemoveParticipantFromBudgetUseCase', () => {
       expect(result.hasData).toBe(false);
       expect(result.errors[0]).toBeInstanceOf(BudgetUpdateFailedError);
       expect(result.errors[0]).toEqual(
-        new BudgetUpdateFailedError(new CannotRemoveOwnerFromParticipantsError().message),
+        new BudgetUpdateFailedError(
+          new CannotRemoveOwnerFromParticipantsError().message,
+        ),
       );
     });
 
@@ -167,7 +169,9 @@ describe('RemoveParticipantFromBudgetUseCase', () => {
     });
 
     it('should fail when authorization service returns error', async () => {
-      const repositoryError = new RepositoryError('Authorization service failed');
+      const repositoryError = new RepositoryError(
+        'Authorization service failed',
+      );
       jest
         .spyOn(budgetAuthorizationServiceStub, 'canAccessBudget')
         .mockResolvedValueOnce(Either.errors([repositoryError]));
@@ -193,7 +197,9 @@ describe('RemoveParticipantFromBudgetUseCase', () => {
 
       await useCase.execute(dto);
 
-      expect(budgetAuthorizationServiceStub.canAccessBudgetCalls).toHaveLength(1);
+      expect(budgetAuthorizationServiceStub.canAccessBudgetCalls).toHaveLength(
+        1,
+      );
       expect(budgetAuthorizationServiceStub.canAccessBudgetCalls[0]).toEqual({
         userId: 'test-user',
         budgetId: validBudget.id,
@@ -213,7 +219,9 @@ describe('RemoveParticipantFromBudgetUseCase', () => {
       const events = validBudget.getEvents();
       if (events.length > 0) {
         expect(eventPublisherStub.publishManyCalls).toHaveLength(1);
-        expect(eventPublisherStub.publishManyCalls[0]).toHaveLength(events.length);
+        expect(eventPublisherStub.publishManyCalls[0]).toHaveLength(
+          events.length,
+        );
       } else {
         expect(eventPublisherStub.publishManyCalls).toHaveLength(0);
       }

--- a/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.ts
+++ b/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.ts
@@ -32,7 +32,9 @@ export class RemoveParticipantFromBudgetUseCase
     );
 
     if (authResult.hasError) {
-      return Either.errors<ApplicationError, UseCaseResponse>(authResult.errors);
+      return Either.errors<ApplicationError, UseCaseResponse>(
+        authResult.errors,
+      );
     }
 
     if (!authResult.data) {

--- a/src/application/use-cases/transaction/create-transaction/CreateTransactionUseCase.spec.ts
+++ b/src/application/use-cases/transaction/create-transaction/CreateTransactionUseCase.spec.ts
@@ -90,6 +90,7 @@ describe('CreateTransactionUseCase', () => {
 
     it('should fail when account does not exist', async () => {
       const nonExistentAccountId = EntityId.create().value!.id;
+      getAccountRepositoryStub.shouldReturnNull = true;
       const dto: CreateTransactionDto = {
         userId,
         description: 'Compra Online',
@@ -160,6 +161,7 @@ describe('CreateTransactionUseCase', () => {
     });
 
     it('should fail when accountId is invalid', async () => {
+      getAccountRepositoryStub.shouldReturnNull = true;
       const dto: CreateTransactionDto = {
         userId,
         description: 'Compra Teste',


### PR DESCRIPTION
## Summary
- add transfer between accounts use case with DTO
- implement domain validations and persistence
- create new application error classes
- cover new use case with extensive unit tests
- update existing transaction tests for missing account scenarios
- comply with lint fixes

## Testing
- `npx eslint . --ext .ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a35e0d6548323baccb74c267779b9