### PR TITLE
Implement DeleteAccountUseCase

### DIFF
--- a/src/application/contracts/repositories/account/ICheckAccountDependenciesRepository.ts
+++ b/src/application/contracts/repositories/account/ICheckAccountDependenciesRepository.ts
@@ -1,0 +1,7 @@
+import { Either } from '@either';
+
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+
+export interface ICheckAccountDependenciesRepository {
+  hasTransactions(accountId: string): Promise<Either<RepositoryError, boolean>>;
+}

--- a/src/application/contracts/repositories/account/IDeleteAccountRepository.ts
+++ b/src/application/contracts/repositories/account/IDeleteAccountRepository.ts
@@ -1,0 +1,7 @@
+import { Either } from '@either';
+
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+
+export interface IDeleteAccountRepository {
+  execute(accountId: string): Promise<Either<RepositoryError, void>>;
+}

--- a/src/application/shared/errors/AccountDeletionFailedError.ts
+++ b/src/application/shared/errors/AccountDeletionFailedError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class AccountDeletionFailedError extends ApplicationError {
+  constructor() {
+    super('Failed to delete account');
+  }
+}

--- a/src/application/shared/errors/CannotDeleteAccountWithTransactionsError.ts
+++ b/src/application/shared/errors/CannotDeleteAccountWithTransactionsError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class CannotDeleteAccountWithTransactionsError extends ApplicationError {
+  constructor() {
+    super('Cannot delete account with existing transactions');
+  }
+}

--- a/src/application/shared/tests/stubs/CheckAccountDependenciesRepositoryStub.ts
+++ b/src/application/shared/tests/stubs/CheckAccountDependenciesRepositoryStub.ts
@@ -1,0 +1,24 @@
+import { Either } from '@either';
+
+import { ICheckAccountDependenciesRepository } from '../../../contracts/repositories/account/ICheckAccountDependenciesRepository';
+import { RepositoryError } from '../../errors/RepositoryError';
+
+export class CheckAccountDependenciesRepositoryStub
+  implements ICheckAccountDependenciesRepository
+{
+  public shouldFail = false;
+  public mockHasTransactions = false;
+  public hasTransactionsCalls: string[] = [];
+
+  async hasTransactions(
+    accountId: string,
+  ): Promise<Either<RepositoryError, boolean>> {
+    this.hasTransactionsCalls.push(accountId);
+
+    if (this.shouldFail) {
+      return Either.error(new RepositoryError('Repository failure'));
+    }
+
+    return Either.success(this.mockHasTransactions);
+  }
+}

--- a/src/application/shared/tests/stubs/DeleteAccountRepositoryStub.ts
+++ b/src/application/shared/tests/stubs/DeleteAccountRepositoryStub.ts
@@ -1,0 +1,19 @@
+import { Either } from '@either';
+
+import { IDeleteAccountRepository } from '../../../contracts/repositories/account/IDeleteAccountRepository';
+import { RepositoryError } from '../../errors/RepositoryError';
+
+export class DeleteAccountRepositoryStub implements IDeleteAccountRepository {
+  public shouldFail = false;
+  public executeCalls: string[] = [];
+
+  async execute(accountId: string): Promise<Either<RepositoryError, void>> {
+    this.executeCalls.push(accountId);
+
+    if (this.shouldFail) {
+      return Either.error(new RepositoryError('Repository failure'));
+    }
+
+    return Either.success();
+  }
+}

--- a/src/application/use-cases/account/delete-account/DeleteAccountDto.ts
+++ b/src/application/use-cases/account/delete-account/DeleteAccountDto.ts
@@ -1,0 +1,4 @@
+export interface DeleteAccountDto {
+  userId: string;
+  accountId: string;
+}

--- a/src/application/use-cases/account/delete-account/DeleteAccountUseCase.spec.ts
+++ b/src/application/use-cases/account/delete-account/DeleteAccountUseCase.spec.ts
@@ -1,0 +1,224 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { AccountDeletedEvent } from '@domain/aggregates/account/events/AccountDeletedEvent';
+import { AccountTypeEnum } from '@domain/aggregates/account/value-objects/account-type/AccountType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+
+import { CannotDeleteAccountWithTransactionsError } from '../../../shared/errors/CannotDeleteAccountWithTransactionsError';
+import { AccountDeletionFailedError } from '../../../shared/errors/AccountDeletionFailedError';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { CheckAccountDependenciesRepositoryStub } from '../../../shared/tests/stubs/CheckAccountDependenciesRepositoryStub';
+import { DeleteAccountRepositoryStub } from '../../../shared/tests/stubs/DeleteAccountRepositoryStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { DeleteAccountDto } from './DeleteAccountDto';
+import { DeleteAccountUseCase } from './DeleteAccountUseCase';
+
+describe('DeleteAccountUseCase', () => {
+  let useCase: DeleteAccountUseCase;
+  let getAccountRepositoryStub: GetAccountRepositoryStub;
+  let deleteAccountRepositoryStub: DeleteAccountRepositoryStub;
+  let checkAccountDependenciesRepositoryStub: CheckAccountDependenciesRepositoryStub;
+  let budgetAuthorizationServiceStub: BudgetAuthorizationServiceStub;
+  let eventPublisherStub: EventPublisherStub;
+  let mockAccount: Account;
+
+  beforeEach(() => {
+    getAccountRepositoryStub = new GetAccountRepositoryStub();
+    deleteAccountRepositoryStub = new DeleteAccountRepositoryStub();
+    checkAccountDependenciesRepositoryStub =
+      new CheckAccountDependenciesRepositoryStub();
+    budgetAuthorizationServiceStub = new BudgetAuthorizationServiceStub();
+    eventPublisherStub = new EventPublisherStub();
+
+    const accountResult = Account.create({
+      name: 'Test Account',
+      type: AccountTypeEnum.CHECKING_ACCOUNT,
+      budgetId: EntityId.create().value!.id,
+      initialBalance: 100,
+    });
+
+    if (accountResult.hasError) {
+      throw new Error(
+        `Failed to create account: ${accountResult.errors.map((e) => e.message).join(', ')}`,
+      );
+    }
+
+    mockAccount = accountResult.data!;
+    mockAccount.clearEvents();
+    getAccountRepositoryStub.mockAccount = mockAccount;
+    budgetAuthorizationServiceStub.mockHasAccess = true;
+
+    useCase = new DeleteAccountUseCase(
+      getAccountRepositoryStub,
+      deleteAccountRepositoryStub,
+      checkAccountDependenciesRepositoryStub,
+      budgetAuthorizationServiceStub,
+      eventPublisherStub,
+    );
+  });
+
+  describe('execute', () => {
+    it('should delete account successfully when user has permission and no transactions', async () => {
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'authorized-user',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+      expect(result.data).toEqual({ id: mockAccount.id });
+      expect(deleteAccountRepositoryStub.executeCalls).toContain(
+        mockAccount.id,
+      );
+      expect(eventPublisherStub.publishManyCalls).toHaveLength(1);
+      expect(eventPublisherStub.publishManyCalls[0][0]).toBeInstanceOf(
+        AccountDeletedEvent,
+      );
+    });
+
+    it('should return error when account not found', async () => {
+      getAccountRepositoryStub.shouldReturnNull = true;
+
+      const dto: DeleteAccountDto = {
+        accountId: 'non-existent',
+        userId: 'user',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(AccountNotFoundError);
+    });
+
+    it('should return error when user has no permission', async () => {
+      budgetAuthorizationServiceStub.mockHasAccess = false;
+
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'unauthorized',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(InsufficientPermissionsError);
+      expect(deleteAccountRepositoryStub.executeCalls).toHaveLength(0);
+    });
+
+    it('should return error when account has transactions', async () => {
+      checkAccountDependenciesRepositoryStub.mockHasTransactions = true;
+
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'authorized-user',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(
+        CannotDeleteAccountWithTransactionsError,
+      );
+      expect(deleteAccountRepositoryStub.executeCalls).toHaveLength(0);
+    });
+
+    it('should return error when get account repository fails', async () => {
+      getAccountRepositoryStub.shouldFail = true;
+
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'user',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(AccountRepositoryError);
+    });
+
+    it('should return error when delete account repository fails', async () => {
+      deleteAccountRepositoryStub.shouldFail = true;
+
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'authorized-user',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(AccountDeletionFailedError);
+    });
+
+    it('should return error when check dependencies repository fails', async () => {
+      checkAccountDependenciesRepositoryStub.shouldFail = true;
+
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'authorized-user',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(AccountRepositoryError);
+    });
+
+    it('should return error when authorization service fails', async () => {
+      budgetAuthorizationServiceStub.shouldFail = true;
+
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'user',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(deleteAccountRepositoryStub.executeCalls).toHaveLength(0);
+    });
+
+    it('should call services with correct parameters', async () => {
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'test-user',
+      };
+
+      await useCase.execute(dto);
+
+      expect(getAccountRepositoryStub.executeCalls).toContain(mockAccount.id);
+      expect(
+        checkAccountDependenciesRepositoryStub.hasTransactionsCalls,
+      ).toContain(mockAccount.id);
+      expect(deleteAccountRepositoryStub.executeCalls).toContain(
+        mockAccount.id,
+      );
+      expect(budgetAuthorizationServiceStub.canAccessBudgetCalls[0]).toEqual({
+        userId: 'test-user',
+        budgetId: mockAccount.budgetId!,
+      });
+    });
+
+    it('should handle event publishing errors gracefully', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      jest
+        .spyOn(eventPublisherStub, 'publishMany')
+        .mockRejectedValueOnce(new Error('publish error'));
+
+      const dto: DeleteAccountDto = {
+        accountId: mockAccount.id,
+        userId: 'authorized-user',
+      };
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/application/use-cases/account/delete-account/DeleteAccountUseCase.ts
+++ b/src/application/use-cases/account/delete-account/DeleteAccountUseCase.ts
@@ -1,0 +1,93 @@
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { ICheckAccountDependenciesRepository } from '../../../contracts/repositories/account/ICheckAccountDependenciesRepository';
+import { IDeleteAccountRepository } from '../../../contracts/repositories/account/IDeleteAccountRepository';
+import { IGetAccountRepository } from '../../../contracts/repositories/account/IGetAccountRepository';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { AccountDeletionFailedError } from '../../../shared/errors/AccountDeletionFailedError';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { CannotDeleteAccountWithTransactionsError } from '../../../shared/errors/CannotDeleteAccountWithTransactionsError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { DeleteAccountDto } from './DeleteAccountDto';
+
+export class DeleteAccountUseCase implements IUseCase<DeleteAccountDto> {
+  constructor(
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly deleteAccountRepository: IDeleteAccountRepository,
+    private readonly checkAccountDependenciesRepository: ICheckAccountDependenciesRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(
+    dto: DeleteAccountDto,
+  ): Promise<Either<ApplicationError, UseCaseResponse>> {
+    const accountResult = await this.getAccountRepository.execute(
+      dto.accountId,
+    );
+
+    if (accountResult.hasError) {
+      return Either.error(new AccountRepositoryError());
+    }
+
+    if (!accountResult.data) {
+      return Either.error(new AccountNotFoundError());
+    }
+
+    const account = accountResult.data;
+
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      account.budgetId!,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors<ApplicationError, UseCaseResponse>(
+        authResult.errors,
+      );
+    }
+
+    if (!authResult.data) {
+      return Either.error(new InsufficientPermissionsError());
+    }
+
+    const dependenciesResult =
+      await this.checkAccountDependenciesRepository.hasTransactions(
+        dto.accountId,
+      );
+
+    if (dependenciesResult.hasError) {
+      return Either.error(new AccountRepositoryError());
+    }
+
+    if (dependenciesResult.data) {
+      return Either.error(new CannotDeleteAccountWithTransactionsError());
+    }
+
+    account.delete();
+
+    const deleteResult = await this.deleteAccountRepository.execute(
+      dto.accountId,
+    );
+
+    if (deleteResult.hasError) {
+      return Either.error(new AccountDeletionFailedError());
+    }
+
+    const events = account.getEvents();
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        account.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success({ id: account.id });
+  }
+}

--- a/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.spec.ts
+++ b/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.spec.ts
@@ -116,7 +116,9 @@ describe('RemoveParticipantFromBudgetUseCase', () => {
       expect(result.hasData).toBe(false);
       expect(result.errors[0]).toBeInstanceOf(BudgetUpdateFailedError);
       expect(result.errors[0]).toEqual(
-        new BudgetUpdateFailedError(new CannotRemoveOwnerFromParticipantsError().message),
+        new BudgetUpdateFailedError(
+          new CannotRemoveOwnerFromParticipantsError().message,
+        ),
       );
     });
 
@@ -167,7 +169,9 @@ describe('RemoveParticipantFromBudgetUseCase', () => {
     });
 
     it('should fail when authorization service returns error', async () => {
-      const repositoryError = new RepositoryError('Authorization service failed');
+      const repositoryError = new RepositoryError(
+        'Authorization service failed',
+      );
       jest
         .spyOn(budgetAuthorizationServiceStub, 'canAccessBudget')
         .mockResolvedValueOnce(Either.errors([repositoryError]));
@@ -193,7 +197,9 @@ describe('RemoveParticipantFromBudgetUseCase', () => {
 
       await useCase.execute(dto);
 
-      expect(budgetAuthorizationServiceStub.canAccessBudgetCalls).toHaveLength(1);
+      expect(budgetAuthorizationServiceStub.canAccessBudgetCalls).toHaveLength(
+        1,
+      );
       expect(budgetAuthorizationServiceStub.canAccessBudgetCalls[0]).toEqual({
         userId: 'test-user',
         budgetId: validBudget.id,
@@ -213,7 +219,9 @@ describe('RemoveParticipantFromBudgetUseCase', () => {
       const events = validBudget.getEvents();
       if (events.length > 0) {
         expect(eventPublisherStub.publishManyCalls).toHaveLength(1);
-        expect(eventPublisherStub.publishManyCalls[0]).toHaveLength(events.length);
+        expect(eventPublisherStub.publishManyCalls[0]).toHaveLength(
+          events.length,
+        );
       } else {
         expect(eventPublisherStub.publishManyCalls).toHaveLength(0);
       }

--- a/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.ts
+++ b/src/application/use-cases/budget/remove-participant/RemoveParticipantFromBudgetUseCase.ts
@@ -32,7 +32,9 @@ export class RemoveParticipantFromBudgetUseCase
     );
 
     if (authResult.hasError) {
-      return Either.errors<ApplicationError, UseCaseResponse>(authResult.errors);
+      return Either.errors<ApplicationError, UseCaseResponse>(
+        authResult.errors,
+      );
     }
 
     if (!authResult.data) {

--- a/src/application/use-cases/transaction/create-transaction/CreateTransactionUseCase.spec.ts
+++ b/src/application/use-cases/transaction/create-transaction/CreateTransactionUseCase.spec.ts
@@ -90,6 +90,7 @@ describe('CreateTransactionUseCase', () => {
 
     it('should fail when account does not exist', async () => {
       const nonExistentAccountId = EntityId.create().value!.id;
+      getAccountRepositoryStub.shouldReturnNull = true;
       const dto: CreateTransactionDto = {
         userId,
         description: 'Compra Online',
@@ -160,6 +161,7 @@ describe('CreateTransactionUseCase', () => {
     });
 
     it('should fail when accountId is invalid', async () => {
+      getAccountRepositoryStub.shouldReturnNull = true;
       const dto: CreateTransactionDto = {
         userId,
         description: 'Compra Teste',

--- a/src/domain/aggregates/account/account-entity/Account.ts
+++ b/src/domain/aggregates/account/account-entity/Account.ts
@@ -11,6 +11,7 @@ import {
 } from '../value-objects/account-type/AccountType';
 import { EntityName } from './../../../shared/value-objects/entity-name/EntityName';
 import { AccountUpdatedEvent } from '../events/AccountUpdatedEvent';
+import { AccountDeletedEvent } from '../events/AccountDeletedEvent';
 import { InvalidAccountDataError } from '../errors/InvalidAccountDataError';
 
 export interface CreateAccountDTO {
@@ -32,6 +33,7 @@ export class Account extends AggregateRoot implements IEntity {
   private readonly _createdAt: Date;
 
   private _updatedAt: Date;
+  private _isDeleted = false;
 
   private constructor(
     private _name: EntityName,
@@ -58,6 +60,10 @@ export class Account extends AggregateRoot implements IEntity {
 
   get updatedAt(): Date {
     return this._updatedAt;
+  }
+
+  get isDeleted(): boolean {
+    return this._isDeleted;
   }
 
   get name(): string | null {
@@ -207,6 +213,21 @@ export class Account extends AggregateRoot implements IEntity {
 
     either.setData(updatedAccount);
     return either;
+  }
+
+  delete(): void {
+    this._updatedAt = new Date();
+    this._isDeleted = true;
+    this.addEvent(
+      new AccountDeletedEvent(
+        this.id,
+        this.budgetId!,
+        this.name!,
+        this.type as AccountTypeEnum,
+        this.balance!,
+        this.description,
+      ),
+    );
   }
 
   static create(data: CreateAccountDTO): Either<DomainError, Account> {

--- a/src/domain/aggregates/account/events/AccountDeletedEvent.spec.ts
+++ b/src/domain/aggregates/account/events/AccountDeletedEvent.spec.ts
@@ -1,0 +1,44 @@
+import { AccountDeletedEvent } from './AccountDeletedEvent';
+import { AccountTypeEnum } from '../value-objects/account-type/AccountType';
+
+describe('AccountDeletedEvent', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-15T10:30:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should create event with all properties', () => {
+    const event = new AccountDeletedEvent(
+      'account-1',
+      'budget-1',
+      'Main',
+      AccountTypeEnum.CHECKING_ACCOUNT,
+      100,
+      'desc',
+    );
+
+    expect(event.aggregateId).toBe('account-1');
+    expect(event.budgetId).toBe('budget-1');
+    expect(event.name).toBe('Main');
+    expect(event.type).toBe(AccountTypeEnum.CHECKING_ACCOUNT);
+    expect(event.balance).toBe(100);
+    expect(event.description).toBe('desc');
+    expect(event.occurredOn).toEqual(new Date('2024-01-15T10:30:00.000Z'));
+    expect(event.eventVersion).toBe(1);
+  });
+
+  it('should allow undefined description', () => {
+    const event = new AccountDeletedEvent(
+      'account',
+      'budget',
+      'name',
+      AccountTypeEnum.CHECKING_ACCOUNT,
+      50,
+    );
+    expect(event.description).toBeUndefined();
+  });
+});

--- a/src/domain/aggregates/account/events/AccountDeletedEvent.ts
+++ b/src/domain/aggregates/account/events/AccountDeletedEvent.ts
@@ -1,0 +1,15 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+import { AccountTypeEnum } from '../value-objects/account-type/AccountType';
+
+export class AccountDeletedEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly budgetId: string,
+    public readonly name: string,
+    public readonly type: AccountTypeEnum,
+    public readonly balance: number,
+    public readonly description?: string,
+  ) {
+    super(aggregateId);
+  }
+}


### PR DESCRIPTION
## Summary
- use aggregate to register AccountDeletedEvent
- add isDeleted tracking and delete method in Account entity
- publish account events after repository deletion
- test AccountDeletedEvent construction
- adjust lint formatting for budget participant removal tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a35b300cc83239f2fc86c2f7bde62