### PR TITLE
Implement DeleteBudgetRepository

### DIFF
--- a/src/infrastructure/database/pg/repositories/budget/delete-budget-repository/DeleteBudgetRepository.spec.ts
+++ b/src/infrastructure/database/pg/repositories/budget/delete-budget-repository/DeleteBudgetRepository.spec.ts
@@ -1,0 +1,100 @@
+import { Either } from '../../../../../../shared/core/either';
+
+import { RepositoryError } from '../../../../../../application/shared/errors/RepositoryError';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import { DeleteBudgetRepository } from './DeleteBudgetRepository';
+
+jest.mock('../../../connection/PostgreSQLConnection');
+
+describe('DeleteBudgetRepository', () => {
+  let repository: DeleteBudgetRepository;
+  let mockQueryOne: jest.MockedFunction<any>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryOne = jest.fn();
+
+    (PostgreSQLConnection.getInstance as jest.Mock).mockReturnValue({
+      queryOne: mockQueryOne,
+    });
+
+    repository = new DeleteBudgetRepository();
+  });
+
+  describe('execute', () => {
+    it('should mark budget as deleted successfully', async () => {
+      mockQueryOne.mockResolvedValue(null);
+
+      const result = await repository.execute('budget-id');
+
+      expect(result.hasError).toBe(false);
+      expect(mockQueryOne).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE budgets'),
+        ['budget-id'],
+      );
+    });
+
+    it('should be idempotent when called multiple times', async () => {
+      mockQueryOne.mockResolvedValue(null);
+
+      const first = await repository.execute('budget-id');
+      const second = await repository.execute('budget-id');
+
+      expect(first.hasError).toBe(false);
+      expect(second.hasError).toBe(false);
+      expect(mockQueryOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not fail when budget is already deleted', async () => {
+      mockQueryOne.mockResolvedValue(null);
+
+      const result = await repository.execute('already-deleted');
+
+      expect(result.hasError).toBe(false);
+      expect(mockQueryOne).toHaveBeenCalledWith(
+        expect.stringContaining('is_deleted = false'),
+        ['already-deleted'],
+      );
+    });
+
+    it('should return error when database query fails', async () => {
+      const dbError = new Error('connection error');
+      mockQueryOne.mockRejectedValue(dbError);
+
+      const result = await repository.execute('budget-id');
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+    });
+
+    it('should use correct SQL query', async () => {
+      mockQueryOne.mockResolvedValue(null);
+
+      await repository.execute('budget-id');
+
+      expect(mockQueryOne).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /UPDATE budgets[\s\S]*SET is_deleted = true, updated_at = NOW()[\s\S]*WHERE id = \$1 AND is_deleted = false/,
+        ),
+        ['budget-id'],
+      );
+    });
+
+    it('should handle non-Error exceptions', async () => {
+      mockQueryOne.mockRejectedValue('fail');
+
+      const result = await repository.execute('budget-id');
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+      expect(result.errors[0].cause).toBeInstanceOf(Error);
+    });
+
+    it('should handle invalid ids', async () => {
+      mockQueryOne.mockResolvedValue(null);
+
+      const resultNull = await repository.execute('');
+      expect(resultNull.hasError).toBe(false);
+    });
+  });
+});

--- a/src/infrastructure/database/pg/repositories/budget/delete-budget-repository/DeleteBudgetRepository.ts
+++ b/src/infrastructure/database/pg/repositories/budget/delete-budget-repository/DeleteBudgetRepository.ts
@@ -1,0 +1,30 @@
+import { Either } from '../../../../../../shared/core/either';
+
+import { IDeleteBudgetRepository } from '../../../../../../application/contracts/repositories/budget/IDeleteBudgetRepository';
+import { RepositoryError } from '../../../../../../application/shared/errors/RepositoryError';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+
+export class DeleteBudgetRepository implements IDeleteBudgetRepository {
+  private readonly connection = PostgreSQLConnection.getInstance();
+
+  async execute(budgetId: string): Promise<Either<RepositoryError, void>> {
+    try {
+      const query = `
+        UPDATE budgets
+        SET is_deleted = true, updated_at = NOW()
+        WHERE id = $1 AND is_deleted = false
+      `;
+
+      await this.connection.queryOne(query, [budgetId]);
+
+      return Either.success<RepositoryError, void>(undefined);
+    } catch (error) {
+      return Either.error<RepositoryError, void>(
+        new RepositoryError(
+          `Failed to delete budget: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          error instanceof Error ? error : new Error('Unknown error'),
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add repository DeleteBudgetRepository for soft deletion
- add accompanying unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa6f69960832381798e0d1a92f93d