### PR TITLE
Implement AddBudgetRepository

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,6 @@ module.exports = {
   moduleNameMapper: {
     '^@either$': '<rootDir>/src/shared/core/either.ts',
     '^@domain/(.*)$': '<rootDir>/src/domain/$1',
+    '^@application/(.*)$': '<rootDir>/src/application/$1',
   },
 };

--- a/src/infrastructure/database/pg/repositories/budget/add-budget-repository/AddBudgetRepository.spec.ts
+++ b/src/infrastructure/database/pg/repositories/budget/add-budget-repository/AddBudgetRepository.spec.ts
@@ -1,0 +1,197 @@
+import { Budget } from '@domain/aggregates/budget/budget-entity/Budget';
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import { BudgetMapper, BudgetRow } from '../../../mappers/BudgetMapper';
+import { AddBudgetRepository } from './AddBudgetRepository';
+
+jest.mock('../../../connection/PostgreSQLConnection');
+jest.mock('../../../mappers/BudgetMapper');
+
+describe('AddBudgetRepository', () => {
+  let repository: AddBudgetRepository;
+  let mockQueryOne: jest.MockedFunction<PostgreSQLConnection['queryOne']>;
+  let mockBudgetMapper: jest.Mocked<typeof BudgetMapper>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryOne = jest.fn();
+    (PostgreSQLConnection.getInstance as jest.Mock).mockReturnValue({
+      queryOne: mockQueryOne,
+    });
+    mockBudgetMapper = BudgetMapper as jest.Mocked<typeof BudgetMapper>;
+    repository = new AddBudgetRepository();
+  });
+
+  describe('execute', () => {
+    it('should add budget successfully', async () => {
+      const mockBudget = Budget.restore({
+        id: 'budget-id',
+        name: 'Test Budget',
+        ownerId: 'owner-id',
+        participantIds: ['participant-1'],
+        isDeleted: false,
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-02'),
+      }).data!;
+
+      const mockRow = {
+        id: 'budget-id',
+        name: 'Test Budget',
+        owner_id: 'owner-id',
+        participant_ids: ['participant-1'],
+        is_deleted: false,
+        created_at: new Date('2023-01-01'),
+        updated_at: new Date('2023-01-02'),
+      };
+
+      mockBudgetMapper.toRow.mockReturnValue({ ...mockRow });
+      mockQueryOne.mockResolvedValue(null);
+
+      const result = await repository.execute(mockBudget);
+
+      expect(result.hasError).toBe(false);
+      expect(mockQueryOne).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO budgets'),
+        [
+          mockRow.id,
+          mockRow.name,
+          mockRow.owner_id,
+          JSON.stringify(mockRow.participant_ids),
+          mockRow.is_deleted,
+          mockRow.created_at,
+          mockRow.updated_at,
+        ],
+      );
+    });
+
+    it('should return error when budget already exists', async () => {
+      const mockBudget = Budget.restore({
+        id: 'existing-budget-id',
+        name: 'Test Budget',
+        ownerId: 'owner-id',
+        participantIds: [],
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }).data!;
+
+      mockBudgetMapper.toRow.mockReturnValue({} as unknown as BudgetRow);
+      const constraintError = new Error('duplicate key value') as Error & {
+        code?: string;
+      };
+      constraintError.code = '23505';
+      mockQueryOne.mockRejectedValue(constraintError);
+
+      const result = await repository.execute(mockBudget);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+      expect(result.errors[0].message).toContain(
+        'Budget with id already exists',
+      );
+    });
+
+    it('should return error when database throws general error', async () => {
+      const mockBudget = Budget.restore({
+        id: 'budget-id',
+        name: 'Test Budget',
+        ownerId: 'owner-id',
+        participantIds: [],
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }).data!;
+
+      mockBudgetMapper.toRow.mockReturnValue({} as unknown as BudgetRow);
+      mockQueryOne.mockRejectedValue(new Error('Connection failed'));
+
+      const result = await repository.execute(mockBudget);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+      expect(result.errors[0].message).toContain('Failed to add budget');
+    });
+
+    it('should use correct SQL query', async () => {
+      const mockBudget = Budget.restore({
+        id: 'budget-id',
+        name: 'Test Budget',
+        ownerId: 'owner-id',
+        participantIds: [],
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }).data!;
+
+      const row = {
+        id: 'budget-id',
+        name: 'Test Budget',
+        owner_id: 'owner-id',
+        participant_ids: [],
+        is_deleted: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      mockBudgetMapper.toRow.mockReturnValue({ ...row });
+      mockQueryOne.mockResolvedValue(null);
+
+      await repository.execute(mockBudget);
+
+      const expected =
+        /INSERT INTO budgets\s*\(\s*id, name, owner_id, participant_ids, is_deleted, created_at, updated_at\s*\)\s*VALUES \(\$1, \$2, \$3, \$4, \$5, \$6, \$7\)/;
+      expect(mockQueryOne.mock.calls[0][0]).toMatch(expected);
+    });
+
+    it('should handle non-Error exceptions', async () => {
+      const mockBudget = Budget.restore({
+        id: 'budget-id',
+        name: 'Test Budget',
+        ownerId: 'owner-id',
+        participantIds: [],
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }).data!;
+
+      mockBudgetMapper.toRow.mockReturnValue({} as unknown as BudgetRow);
+      mockQueryOne.mockRejectedValue('fail');
+
+      const result = await repository.execute(mockBudget);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+      expect(result.errors[0].cause).toBeInstanceOf(Error);
+      expect(result.errors[0].cause!.message).toBe('Unknown error');
+    });
+
+    it('should call queryOne once', async () => {
+      const mockBudget = Budget.restore({
+        id: 'budget-id',
+        name: 'Test Budget',
+        ownerId: 'owner-id',
+        participantIds: [],
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }).data!;
+
+      const row = {
+        id: 'budget-id',
+        name: 'Test Budget',
+        owner_id: 'owner-id',
+        participant_ids: [],
+        is_deleted: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      mockBudgetMapper.toRow.mockReturnValue({ ...row });
+      mockQueryOne.mockResolvedValue(null);
+
+      await repository.execute(mockBudget);
+
+      expect(mockQueryOne).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/infrastructure/database/pg/repositories/budget/add-budget-repository/AddBudgetRepository.ts
+++ b/src/infrastructure/database/pg/repositories/budget/add-budget-repository/AddBudgetRepository.ts
@@ -1,0 +1,53 @@
+import { Budget } from '@domain/aggregates/budget/budget-entity/Budget';
+import { Either } from '@either';
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import { BudgetMapper } from '../../../mappers/BudgetMapper';
+
+import { IAddBudgetRepository } from '@application/contracts/repositories/budget/IAddBudgetRepository';
+
+export class AddBudgetRepository implements IAddBudgetRepository {
+  async execute(budget: Budget): Promise<Either<RepositoryError, void>> {
+    try {
+      const connection = PostgreSQLConnection.getInstance();
+      const row = BudgetMapper.toRow(budget);
+
+      const query = `
+        INSERT INTO budgets (
+          id, name, owner_id, participant_ids, is_deleted, created_at, updated_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+      `;
+
+      const params = [
+        row.id,
+        row.name,
+        row.owner_id,
+        JSON.stringify(row.participant_ids),
+        row.is_deleted,
+        row.created_at,
+        row.updated_at,
+      ];
+
+      await connection.queryOne(query, params);
+      return Either.success<RepositoryError, void>(undefined);
+    } catch (error) {
+      const err = error as Error & { code?: string };
+      if (err.code === '23505') {
+        return Either.error(
+          new RepositoryError(
+            `Budget with id already exists: ${err.message}`,
+            err instanceof Error ? err : new Error('Unknown error'),
+          ),
+        );
+      }
+      return Either.error(
+        new RepositoryError(
+          `Failed to add budget: ${
+            err instanceof Error ? err.message : 'Unknown error'
+          }`,
+          err instanceof Error ? err : new Error('Unknown error'),
+        ),
+      );
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */
@@ -26,13 +26,14 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": "./src",
     "paths": {
       "@domain/*": ["domain/*"],
-      "@either": ["shared/core/either.ts"]
+      "@either": ["shared/core/either.ts"],
+      "@application/*": ["application/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
@@ -62,7 +63,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
@@ -83,12 +84,12 @@
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -111,8 +112,14 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": ["src"],
-  "exclude": ["migrations", "src/**/*.spec.ts", "src/**/*.test.ts", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": [
+    "migrations",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- implement repository for inserting budgets
- add comprehensive unit tests for AddBudgetRepository
- configure alias for application layer in tsconfig and jest

## Testing
- `npm test AddBudgetRepository`
- `npm run lint` *(fails: problems in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687b0e6743888323a1ac349deca9aaba