### PR TITLE
Implement transaction repository infrastructure

### DIFF
--- a/src/infrastructure/database/pg/mappers/transaction/TransactionMapper.spec.ts
+++ b/src/infrastructure/database/pg/mappers/transaction/TransactionMapper.spec.ts
@@ -1,0 +1,98 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionStatusEnum } from '@domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+
+import { TransactionMapper, TransactionRow } from './TransactionMapper';
+
+describe('TransactionMapper', () => {
+  describe('toDomain', () => {
+    it('should convert valid row to Transaction entity', () => {
+      const row: TransactionRow = {
+        id: EntityId.create().value!.id,
+        description: 'Test',
+        amount: '100.50',
+        type: 'EXPENSE',
+        account_id: EntityId.create().value!.id,
+        category_id: EntityId.create().value!.id,
+        budget_id: EntityId.create().value!.id,
+        transaction_date: new Date('2024-01-01'),
+        status: 'SCHEDULED',
+        is_deleted: false,
+        created_at: new Date('2024-01-01'),
+        updated_at: new Date('2024-01-02'),
+      };
+
+      const result = TransactionMapper.toDomain(row);
+      expect(result.hasError).toBe(false);
+      const tx = result.data!;
+      expect(tx.description).toBe('Test');
+      expect(tx.amount).toBe(10050);
+      expect(tx.type).toBe(TransactionTypeEnum.EXPENSE);
+      expect(tx.categoryId).toBe(row.category_id!);
+      expect(tx.status).toBe(TransactionStatusEnum.SCHEDULED);
+    });
+
+    it('should handle null category_id', () => {
+      const row: TransactionRow = {
+        id: EntityId.create().value!.id,
+        description: 'Test',
+        amount: '50.00',
+        type: 'INCOME',
+        account_id: EntityId.create().value!.id,
+        category_id: null,
+        budget_id: EntityId.create().value!.id,
+        transaction_date: new Date('2024-01-02'),
+        status: 'COMPLETED',
+        is_deleted: false,
+        created_at: new Date('2024-01-02'),
+        updated_at: new Date('2024-01-03'),
+      };
+
+      const result = TransactionMapper.toDomain(row);
+      expect(result.hasError).toBe(false);
+    });
+
+    it('should return error with invalid data', () => {
+      const row: TransactionRow = {
+        id: 'invalid',
+        description: 'Te',
+        amount: 'abc',
+        type: 'WRONG',
+        account_id: 'invalid',
+        category_id: 'invalid',
+        budget_id: 'invalid',
+        transaction_date: new Date('2024-01-01'),
+        status: 'WRONG',
+        is_deleted: false,
+        created_at: new Date('2024-01-01'),
+        updated_at: new Date('2024-01-01'),
+      };
+
+      const result = TransactionMapper.toDomain(row);
+      expect(result.hasError).toBe(true);
+    });
+  });
+
+  describe('toRow', () => {
+    it('should convert Transaction entity to row', () => {
+      const tx = Transaction.create({
+        description: 'RowTest',
+        amount: 12345,
+        type: TransactionTypeEnum.INCOME,
+        transactionDate: new Date('2024-01-05'),
+        categoryId: EntityId.create().value!.id,
+        budgetId: EntityId.create().value!.id,
+        accountId: EntityId.create().value!.id,
+        status: TransactionStatusEnum.SCHEDULED,
+      }).data!;
+
+      const row = TransactionMapper.toRow(tx);
+      expect(row.id).toBe(tx.id);
+      expect(row.amount).toBe('123.45');
+      expect(row.type).toBe('INCOME');
+      expect(row.category_id).toBe(tx.categoryId);
+      expect(row.status).toBe('SCHEDULED');
+    });
+  });
+});

--- a/src/infrastructure/database/pg/mappers/transaction/TransactionMapper.ts
+++ b/src/infrastructure/database/pg/mappers/transaction/TransactionMapper.ts
@@ -1,0 +1,58 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { TransactionStatusEnum } from '@domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus';
+
+export interface TransactionRow {
+  id: string;
+  description: string;
+  amount: string;
+  type: string;
+  account_id: string;
+  category_id: string | null;
+  budget_id: string;
+  transaction_date: Date;
+  status: string;
+  is_deleted: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export class TransactionMapper {
+  static toDomain(row: TransactionRow): Either<DomainError, Transaction> {
+    const amount = Math.round(parseFloat(row.amount) * 100);
+
+    return Transaction.restore({
+      id: row.id,
+      description: row.description,
+      amount,
+      type: row.type as TransactionTypeEnum,
+      accountId: row.account_id,
+      categoryId: row.category_id,
+      budgetId: row.budget_id,
+      transactionDate: row.transaction_date,
+      status: row.status as TransactionStatusEnum,
+      isDeleted: row.is_deleted,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    });
+  }
+
+  static toRow(transaction: Transaction): TransactionRow {
+    return {
+      id: transaction.id,
+      description: transaction.description,
+      amount: (transaction.amount / 100).toFixed(2),
+      type: transaction.type,
+      account_id: transaction.accountId,
+      category_id: transaction.categoryId || null,
+      budget_id: transaction.budgetId,
+      transaction_date: transaction.transactionDate,
+      status: transaction.status,
+      is_deleted: transaction.isDeleted,
+      created_at: transaction.createdAt,
+      updated_at: transaction.updatedAt,
+    } as TransactionRow;
+  }
+}

--- a/src/infrastructure/database/pg/repositories/transaction/add-transaction-repository/AddTransactionRepository.spec.ts
+++ b/src/infrastructure/database/pg/repositories/transaction/add-transaction-repository/AddTransactionRepository.spec.ts
@@ -1,0 +1,88 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionStatusEnum } from '@domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import {
+  TransactionMapper,
+  TransactionRow,
+} from '../../../mappers/transaction/TransactionMapper';
+import { AddTransactionRepository } from './AddTransactionRepository';
+
+jest.mock('../../../connection/PostgreSQLConnection');
+jest.mock('../../../mappers/transaction/TransactionMapper');
+
+describe('AddTransactionRepository', () => {
+  let repository: AddTransactionRepository;
+  let mockQueryOne: jest.MockedFunction<PostgreSQLConnection['queryOne']>;
+  let mockMapper: jest.Mocked<typeof TransactionMapper>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryOne = jest.fn();
+    (PostgreSQLConnection.getInstance as jest.Mock).mockReturnValue({
+      queryOne: mockQueryOne,
+    });
+    mockMapper = TransactionMapper as jest.Mocked<typeof TransactionMapper>;
+    repository = new AddTransactionRepository();
+  });
+
+  describe('execute', () => {
+    const tx = Transaction.create({
+      description: 'Add',
+      amount: 1000,
+      type: TransactionTypeEnum.INCOME,
+      transactionDate: new Date('2024-01-01'),
+      categoryId: EntityId.create().value!.id,
+      budgetId: EntityId.create().value!.id,
+      accountId: EntityId.create().value!.id,
+      status: TransactionStatusEnum.SCHEDULED,
+    }).data!;
+
+    const row: TransactionRow = {
+      id: tx.id,
+      description: tx.description,
+      amount: '10.00',
+      type: tx.type,
+      account_id: tx.accountId,
+      category_id: tx.categoryId,
+      budget_id: tx.budgetId,
+      transaction_date: tx.transactionDate,
+      status: tx.status,
+      is_deleted: tx.isDeleted,
+      created_at: tx.createdAt,
+      updated_at: tx.updatedAt,
+    };
+
+    it('should add transaction successfully', async () => {
+      mockMapper.toRow.mockReturnValue({ ...row });
+      mockQueryOne.mockResolvedValue(null);
+
+      const result = await repository.execute(tx);
+      expect(result.hasError).toBe(false);
+      expect(mockQueryOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return error when transaction already exists', async () => {
+      mockMapper.toRow.mockReturnValue({ ...row });
+      const err = new Error('dup') as Error & { code?: string };
+      err.code = '23505';
+      mockQueryOne.mockRejectedValue(err);
+
+      const result = await repository.execute(tx);
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+    });
+
+    it('should return error on connection fail', async () => {
+      mockMapper.toRow.mockReturnValue({ ...row });
+      const err = new Error('fail');
+      mockQueryOne.mockRejectedValue(err);
+
+      const result = await repository.execute(tx);
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+    });
+  });
+});

--- a/src/infrastructure/database/pg/repositories/transaction/add-transaction-repository/AddTransactionRepository.ts
+++ b/src/infrastructure/database/pg/repositories/transaction/add-transaction-repository/AddTransactionRepository.ts
@@ -1,0 +1,55 @@
+import { IAddTransactionRepository } from '@application/contracts/repositories/transaction/IAddTransactionRepository';
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { Either } from '@either';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import { TransactionMapper } from '../../../mappers/transaction/TransactionMapper';
+
+export class AddTransactionRepository implements IAddTransactionRepository {
+  async execute(
+    transaction: Transaction,
+  ): Promise<Either<RepositoryError, void>> {
+    try {
+      const connection = PostgreSQLConnection.getInstance();
+      const row = TransactionMapper.toRow(transaction);
+      const query = `
+        INSERT INTO transactions (
+          id, description, amount, type, account_id, category_id,
+          budget_id, transaction_date, status, is_deleted, created_at, updated_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      `;
+      const params = [
+        row.id,
+        row.description,
+        row.amount,
+        row.type,
+        row.account_id,
+        row.category_id,
+        row.budget_id,
+        row.transaction_date,
+        row.status,
+        row.is_deleted,
+        row.created_at,
+        row.updated_at,
+      ];
+      await connection.queryOne(query, params);
+      return Either.success<RepositoryError, void>(undefined);
+    } catch (error) {
+      const err = error as Error & { code?: string };
+      if (err.code === '23505') {
+        return Either.error(
+          new RepositoryError(
+            `Transaction with id already exists: ${err.message}`,
+            err instanceof Error ? err : new Error('Unknown error'),
+          ),
+        );
+      }
+      return Either.error(
+        new RepositoryError(
+          `Failed to add transaction: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          err instanceof Error ? err : new Error('Unknown error'),
+        ),
+      );
+    }
+  }
+}

--- a/src/infrastructure/database/pg/repositories/transaction/delete-transaction-repository/DeleteTransactionRepository.spec.ts
+++ b/src/infrastructure/database/pg/repositories/transaction/delete-transaction-repository/DeleteTransactionRepository.spec.ts
@@ -1,0 +1,43 @@
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import { DeleteTransactionRepository } from './DeleteTransactionRepository';
+
+jest.mock('../../../connection/PostgreSQLConnection');
+
+describe('DeleteTransactionRepository', () => {
+  let repository: DeleteTransactionRepository;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockQueryOne: jest.MockedFunction<any>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryOne = jest.fn();
+    (PostgreSQLConnection.getInstance as jest.Mock).mockReturnValue({
+      queryOne: mockQueryOne,
+    });
+    repository = new DeleteTransactionRepository();
+  });
+
+  describe('execute', () => {
+    it('should mark transaction as deleted', async () => {
+      mockQueryOne.mockResolvedValue(null);
+      const result = await repository.execute('id');
+      expect(result.hasError).toBe(false);
+      expect(mockQueryOne).toHaveBeenCalledWith(expect.any(String), ['id']);
+    });
+
+    it('should be idempotent', async () => {
+      mockQueryOne.mockResolvedValue(null);
+      await repository.execute('id');
+      await repository.execute('id');
+      expect(mockQueryOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return error on db failure', async () => {
+      mockQueryOne.mockRejectedValue(new Error('db'));
+      const result = await repository.execute('id');
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+    });
+  });
+});

--- a/src/infrastructure/database/pg/repositories/transaction/delete-transaction-repository/DeleteTransactionRepository.ts
+++ b/src/infrastructure/database/pg/repositories/transaction/delete-transaction-repository/DeleteTransactionRepository.ts
@@ -1,0 +1,30 @@
+import { IDeleteTransactionRepository } from '@application/contracts/repositories/transaction/IDeleteTransactionRepository';
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { Either } from '@either';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+
+export class DeleteTransactionRepository
+  implements IDeleteTransactionRepository
+{
+  private readonly connection = PostgreSQLConnection.getInstance();
+
+  async execute(id: string): Promise<Either<RepositoryError, void>> {
+    try {
+      const query = `
+        UPDATE transactions
+        SET is_deleted = true, updated_at = NOW()
+        WHERE id = $1 AND is_deleted = false
+      `;
+
+      await this.connection.queryOne(query, [id]);
+      return Either.success<RepositoryError, void>(undefined);
+    } catch (error) {
+      return Either.error(
+        new RepositoryError(
+          `Failed to delete transaction: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          error instanceof Error ? error : new Error('Unknown error'),
+        ),
+      );
+    }
+  }
+}

--- a/src/infrastructure/database/pg/repositories/transaction/get-transaction-repository/GetTransactionRepository.spec.ts
+++ b/src/infrastructure/database/pg/repositories/transaction/get-transaction-repository/GetTransactionRepository.spec.ts
@@ -1,0 +1,108 @@
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { DomainError } from '@domain/shared/DomainError';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { Either } from '@either';
+
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import {
+  TransactionMapper,
+  TransactionRow,
+} from '../../../mappers/transaction/TransactionMapper';
+import { GetTransactionRepository } from './GetTransactionRepository';
+
+jest.mock('../../../connection/PostgreSQLConnection');
+jest.mock('../../../mappers/transaction/TransactionMapper');
+
+class TestDomainError extends DomainError {
+  constructor(message: string) {
+    super(message);
+    this.fieldName = 'test';
+  }
+}
+
+describe('GetTransactionRepository', () => {
+  let repository: GetTransactionRepository;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockQueryOne: jest.MockedFunction<any>;
+  let mockMapper: jest.Mocked<typeof TransactionMapper>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryOne = jest.fn();
+    mockMapper = TransactionMapper as jest.Mocked<typeof TransactionMapper>;
+    (PostgreSQLConnection.getInstance as jest.Mock).mockReturnValue({
+      queryOne: mockQueryOne,
+    });
+    repository = new GetTransactionRepository();
+  });
+
+  describe('execute', () => {
+    const validId = EntityId.create().value!.id;
+    const row: TransactionRow = {
+      id: validId,
+      description: 'Test',
+      amount: '20.00',
+      type: 'EXPENSE',
+      account_id: EntityId.create().value!.id,
+      category_id: EntityId.create().value!.id,
+      budget_id: EntityId.create().value!.id,
+      transaction_date: new Date('2024-01-01'),
+      status: 'SCHEDULED',
+      is_deleted: false,
+      created_at: new Date('2024-01-01'),
+      updated_at: new Date('2024-01-02'),
+    };
+
+    it('should return transaction when found', async () => {
+      const tx = {} as Transaction;
+      mockQueryOne.mockResolvedValue(row);
+      mockMapper.toDomain.mockReturnValue(Either.success(tx));
+
+      const result = await repository.execute(validId);
+      expect(result.hasError).toBe(false);
+      expect(result.data).toBe(tx);
+    });
+
+    it('should handle null category_id', async () => {
+      const rowNull = { ...row, category_id: null } as TransactionRow;
+      const tx = {} as Transaction;
+      mockQueryOne.mockResolvedValue(rowNull);
+      mockMapper.toDomain.mockReturnValue(Either.success(tx));
+
+      const result = await repository.execute(validId);
+      expect(result.hasError).toBe(false);
+      expect(result.data).toBe(tx);
+    });
+
+    it('should return null when not found', async () => {
+      mockQueryOne.mockResolvedValue(null);
+
+      const result = await repository.execute(validId);
+      expect(result.hasError).toBe(false);
+      expect(result.data).toBeNull();
+      expect(mockMapper.toDomain).not.toHaveBeenCalled();
+    });
+
+    it('should return error when mapping fails', async () => {
+      mockQueryOne.mockResolvedValue(row);
+      mockMapper.toDomain.mockReturnValue(
+        Either.error(new TestDomainError('map')),
+      );
+
+      const result = await repository.execute(validId);
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+    });
+
+    it('should return error on db failure', async () => {
+      const err = new Error('fail');
+      mockQueryOne.mockRejectedValue(err);
+
+      const result = await repository.execute(validId);
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+      expect(result.errors[0].cause).toBe(err);
+    });
+  });
+});

--- a/src/infrastructure/database/pg/repositories/transaction/get-transaction-repository/GetTransactionRepository.ts
+++ b/src/infrastructure/database/pg/repositories/transaction/get-transaction-repository/GetTransactionRepository.ts
@@ -1,0 +1,54 @@
+import { IGetTransactionRepository } from '@application/contracts/repositories/transaction/IGetTransactionRepository';
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { Either } from '@either';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import {
+  TransactionMapper,
+  TransactionRow,
+} from '../../../mappers/transaction/TransactionMapper';
+
+export class GetTransactionRepository implements IGetTransactionRepository {
+  async execute(
+    id: string,
+  ): Promise<Either<RepositoryError, Transaction | null>> {
+    try {
+      const connection = PostgreSQLConnection.getInstance();
+      const query = `
+        SELECT
+          id, description, amount, type, account_id, category_id,
+          budget_id, transaction_date, status, is_deleted, created_at, updated_at
+        FROM transactions
+        WHERE id = $1 AND is_deleted = false
+      `;
+
+      const row = await connection.queryOne<TransactionRow>(query, [id]);
+
+      if (!row) {
+        return Either.success<RepositoryError, Transaction | null>(null);
+      }
+
+      const txResult = TransactionMapper.toDomain(row);
+      if (txResult.hasError) {
+        return Either.error(
+          new RepositoryError(
+            `Failed to map transaction: ${txResult.errors.map((e) => e.message).join(', ')}`,
+            new Error('Mapping error'),
+          ),
+        );
+      }
+
+      return Either.success<RepositoryError, Transaction | null>(
+        txResult.data!,
+      );
+    } catch (error) {
+      return Either.error(
+        new RepositoryError(
+          'Failed to get transaction: ' +
+            (error instanceof Error ? error.message : 'Unknown error'),
+          error instanceof Error ? error : new Error('Unknown error'),
+        ),
+      );
+    }
+  }
+}

--- a/src/infrastructure/database/pg/repositories/transaction/save-transaction-repository/SaveTransactionRepository.spec.ts
+++ b/src/infrastructure/database/pg/repositories/transaction/save-transaction-repository/SaveTransactionRepository.spec.ts
@@ -1,0 +1,95 @@
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionStatusEnum } from '@domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import {
+  TransactionMapper,
+  TransactionRow,
+} from '../../../mappers/transaction/TransactionMapper';
+import { SaveTransactionRepository } from './SaveTransactionRepository';
+
+jest.mock('../../../connection/PostgreSQLConnection');
+jest.mock('../../../mappers/transaction/TransactionMapper');
+
+describe('SaveTransactionRepository', () => {
+  let repository: SaveTransactionRepository;
+  let mockQueryOne: jest.MockedFunction<PostgreSQLConnection['queryOne']>;
+  let mockMapper: jest.Mocked<typeof TransactionMapper>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryOne = jest.fn();
+    mockMapper = TransactionMapper as jest.Mocked<typeof TransactionMapper>;
+    (PostgreSQLConnection.getInstance as jest.Mock).mockReturnValue({
+      queryOne: mockQueryOne,
+    });
+    repository = new SaveTransactionRepository();
+  });
+
+  describe('execute', () => {
+    const tx = Transaction.create({
+      description: 'save',
+      amount: 2000,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: new Date('2024-01-10'),
+      categoryId: EntityId.create().value!.id,
+      budgetId: EntityId.create().value!.id,
+      accountId: EntityId.create().value!.id,
+      status: TransactionStatusEnum.SCHEDULED,
+    }).data!;
+
+    const row: TransactionRow = {
+      id: tx.id,
+      description: tx.description,
+      amount: '20.00',
+      type: tx.type,
+      account_id: tx.accountId,
+      category_id: tx.categoryId,
+      budget_id: tx.budgetId,
+      transaction_date: tx.transactionDate,
+      status: tx.status,
+      is_deleted: tx.isDeleted,
+      created_at: tx.createdAt,
+      updated_at: tx.updatedAt,
+    };
+
+    it('should save transaction successfully', async () => {
+      mockMapper.toRow.mockReturnValue({ ...row });
+      mockQueryOne.mockResolvedValue(null);
+
+      const result = await repository.execute(tx);
+      expect(result.hasError).toBe(false);
+    });
+
+    it('should update existing transaction', async () => {
+      mockMapper.toRow.mockReturnValue({ ...row });
+      mockQueryOne.mockResolvedValue(null);
+
+      await repository.execute(tx);
+      const query = mockQueryOne.mock.calls[0][0];
+      expect(query).toContain('ON CONFLICT');
+    });
+
+    it('should return error when db fails', async () => {
+      mockMapper.toRow.mockReturnValue({ ...row });
+      const err = new Error('db');
+      mockQueryOne.mockRejectedValue(err);
+
+      const result = await repository.execute(tx);
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+    });
+
+    it('should return error when mapping fails', async () => {
+      mockMapper.toRow.mockImplementation(() => {
+        throw new Error('map');
+      });
+
+      const result = await repository.execute(tx);
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(RepositoryError);
+    });
+  });
+});

--- a/src/infrastructure/database/pg/repositories/transaction/save-transaction-repository/SaveTransactionRepository.ts
+++ b/src/infrastructure/database/pg/repositories/transaction/save-transaction-repository/SaveTransactionRepository.ts
@@ -1,0 +1,75 @@
+import { ISaveTransactionRepository } from '@application/contracts/repositories/transaction/ISaveTransactionRepository';
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { Either } from '@either';
+import { PostgreSQLConnection } from '../../../connection/PostgreSQLConnection';
+import {
+  TransactionMapper,
+  TransactionRow,
+} from '../../../mappers/transaction/TransactionMapper';
+
+export class SaveTransactionRepository implements ISaveTransactionRepository {
+  private readonly connection = PostgreSQLConnection.getInstance();
+
+  async execute(
+    transaction: Transaction,
+  ): Promise<Either<RepositoryError, void>> {
+    let row: TransactionRow;
+    try {
+      row = TransactionMapper.toRow(transaction);
+      row.updated_at = new Date();
+    } catch (error) {
+      return Either.error(
+        new RepositoryError(
+          `Failed to map transaction: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          error instanceof Error ? error : new Error('Unknown error'),
+        ),
+      );
+    }
+
+    try {
+      const query = `
+        INSERT INTO transactions (
+          id, description, amount, type, account_id, category_id,
+          budget_id, transaction_date, status, is_deleted, created_at, updated_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        ON CONFLICT (id) DO UPDATE SET
+          description = EXCLUDED.description,
+          amount = EXCLUDED.amount,
+          type = EXCLUDED.type,
+          account_id = EXCLUDED.account_id,
+          category_id = EXCLUDED.category_id,
+          budget_id = EXCLUDED.budget_id,
+          transaction_date = EXCLUDED.transaction_date,
+          status = EXCLUDED.status,
+          is_deleted = EXCLUDED.is_deleted,
+          updated_at = EXCLUDED.updated_at
+      `;
+
+      const params = [
+        row.id,
+        row.description,
+        row.amount,
+        row.type,
+        row.account_id,
+        row.category_id,
+        row.budget_id,
+        row.transaction_date,
+        row.status,
+        row.is_deleted,
+        row.created_at,
+        row.updated_at,
+      ];
+
+      await this.connection.queryOne(query, params);
+      return Either.success<RepositoryError, void>(undefined);
+    } catch (error) {
+      return Either.error(
+        new RepositoryError(
+          'Database error',
+          error instanceof Error ? error : new Error('Unknown error'),
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `Transaction.restore` factory for entity reconstitution
- map PostgreSQL rows in `TransactionMapper`
- implement add/get/save/delete repositories for Transaction
- provide comprehensive Jest tests for mapper and repositories

## Testing
- `npm run lint`
- `npm test -- transaction`

------
https://chatgpt.com/codex/tasks/task_e_687b16bf58f08323851e53b4bfb99271