### PR TITLE
Implement credit card bill domain events

### DIFF
--- a/src/domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill.ts
+++ b/src/domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill.ts
@@ -1,6 +1,8 @@
 import { Either } from '@either';
 
+import { AggregateRoot } from '../../../shared/AggregateRoot';
 import { DomainError } from '../../../shared/DomainError';
+import { IEntity } from '../../../shared/IEntity';
 import { EntityId } from '../../../shared/value-objects/entity-id/EntityId';
 import { MoneyVo } from '../../../shared/value-objects/money-vo/MoneyVo';
 import { InvalidCreditCardBillDateError } from '../errors/InvalidCreditCardBillDateError';
@@ -8,6 +10,13 @@ import {
   BillStatus,
   BillStatusEnum,
 } from '../value-objects/bill-status/BillStatus';
+import { CreditCardBillAlreadyDeletedError } from '../errors/CreditCardBillAlreadyDeletedError';
+import { CreditCardBillCannotBeUpdatedError } from '../errors/CreditCardBillCannotBeUpdatedError';
+import { CreditCardBillCreatedEvent } from '../events/CreditCardBillCreatedEvent';
+import { CreditCardBillPaidEvent } from '../events/CreditCardBillPaidEvent';
+import { CreditCardBillDeletedEvent } from '../events/CreditCardBillDeletedEvent';
+import { CreditCardBillReopenedEvent } from '../events/CreditCardBillReopenedEvent';
+import { CreditCardBillUpdatedEvent } from '../events/CreditCardBillUpdatedEvent';
 
 export interface CreateCreditCardBillDTO {
   creditCardId: string;
@@ -17,12 +26,32 @@ export interface CreateCreditCardBillDTO {
   status?: BillStatusEnum;
 }
 
-export class CreditCardBill {
+export interface UpdateCreditCardBillDTO {
+  closingDate: Date;
+  dueDate: Date;
+  amount: number;
+}
+
+export interface RestoreCreditCardBillDTO {
+  id: string;
+  creditCardId: string;
+  closingDate: Date;
+  dueDate: Date;
+  amount: number;
+  status: BillStatusEnum;
+  paidAt?: Date;
+  isDeleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class CreditCardBill extends AggregateRoot implements IEntity {
   private readonly _id: EntityId;
   private readonly _createdAt: Date;
 
   private _updatedAt: Date;
   private _paidAt?: Date;
+  private _isDeleted = false;
 
   private constructor(
     private _creditCardId: EntityId,
@@ -30,8 +59,10 @@ export class CreditCardBill {
     private _dueDate: Date,
     private _amount: MoneyVo,
     private _status: BillStatus,
+    existingId?: EntityId,
   ) {
-    this._id = EntityId.create();
+    super();
+    this._id = existingId || EntityId.create();
     this._createdAt = new Date();
     this._updatedAt = new Date();
   }
@@ -72,6 +103,10 @@ export class CreditCardBill {
     return this._paidAt;
   }
 
+  get isDeleted(): boolean {
+    return this._isDeleted;
+  }
+
   get isOverdue(): boolean {
     const today = new Date();
     return this._dueDate < today && this.status !== BillStatusEnum.PAID;
@@ -83,7 +118,16 @@ export class CreditCardBill {
     return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
   }
 
+  canBeUpdated(): boolean {
+    return !this._isDeleted && this.status !== BillStatusEnum.PAID;
+  }
+
   markAsPaid(): Either<DomainError, void> {
+    if (this._isDeleted)
+      return Either.error<DomainError, void>(
+        new CreditCardBillAlreadyDeletedError(),
+      );
+
     if (this.status === BillStatusEnum.PAID)
       return Either.success<DomainError, void>();
 
@@ -95,6 +139,109 @@ export class CreditCardBill {
     this._paidAt = new Date();
     this._updatedAt = new Date();
 
+    this.addEvent(
+      new CreditCardBillPaidEvent(
+        this.id,
+        this.creditCardId,
+        this.amount,
+        this._paidAt,
+      ),
+    );
+
+    return Either.success<DomainError, void>();
+  }
+
+  reopen(): Either<DomainError, void> {
+    if (this._isDeleted)
+      return Either.error<DomainError, void>(
+        new CreditCardBillAlreadyDeletedError(),
+      );
+
+    if (this.status !== BillStatusEnum.PAID)
+      return Either.error<DomainError, void>(
+        new CreditCardBillCannotBeUpdatedError(
+          'Only paid bills can be reopened',
+        ),
+      );
+
+    const openStatus = BillStatus.create(BillStatusEnum.OPEN);
+    if (openStatus.hasError)
+      return Either.errors<DomainError, void>(openStatus.errors);
+
+    this._status = openStatus;
+    this._paidAt = undefined;
+    this._updatedAt = new Date();
+
+    this.addEvent(new CreditCardBillReopenedEvent(this.id, this.creditCardId));
+
+    return Either.success<DomainError, void>();
+  }
+
+  updateAmount(amount: number): Either<DomainError, void> {
+    return this.update({
+      amount,
+      closingDate: this._closingDate,
+      dueDate: this._dueDate,
+    });
+  }
+
+  update(data: UpdateCreditCardBillDTO): Either<DomainError, void> {
+    if (this._isDeleted)
+      return Either.error<DomainError, void>(
+        new CreditCardBillAlreadyDeletedError(),
+      );
+
+    if (!this.canBeUpdated())
+      return Either.error<DomainError, void>(
+        new CreditCardBillCannotBeUpdatedError(),
+      );
+
+    const either = new Either<DomainError, void>();
+
+    if (data.closingDate >= data.dueDate)
+      either.addError(new InvalidCreditCardBillDateError());
+
+    const amountVo = MoneyVo.create(data.amount);
+    if (amountVo.hasError) either.addManyErrors(amountVo.errors);
+
+    if (either.hasError) return either;
+
+    const changed =
+      this._closingDate.getTime() !== data.closingDate.getTime() ||
+      this._dueDate.getTime() !== data.dueDate.getTime() ||
+      this._amount.value!.cents !== amountVo.value!.cents;
+
+    this._closingDate = data.closingDate;
+    this._dueDate = data.dueDate;
+    this._amount = amountVo;
+    this._updatedAt = new Date();
+
+    if (changed) {
+      this.addEvent(
+        new CreditCardBillUpdatedEvent(
+          this.id,
+          this.creditCardId,
+          this._closingDate,
+          this._dueDate,
+          this.amount,
+          this.status,
+        ),
+      );
+    }
+
+    either.setData();
+    return either;
+  }
+
+  delete(): Either<DomainError, void> {
+    if (this._isDeleted)
+      return Either.error<DomainError, void>(
+        new CreditCardBillAlreadyDeletedError(),
+      );
+
+    this._isDeleted = true;
+    this._updatedAt = new Date();
+    this.addEvent(new CreditCardBillDeletedEvent(this.id, this.creditCardId));
     return Either.success<DomainError, void>();
   }
 
@@ -125,6 +272,60 @@ export class CreditCardBill {
       status,
     );
 
+    bill.addEvent(
+      new CreditCardBillCreatedEvent(
+        bill.id,
+        bill.creditCardId,
+        bill.closingDate,
+        bill.dueDate,
+        bill.amount,
+        bill.status,
+      ),
+    );
+
     return Either.success<DomainError, CreditCardBill>(bill);
+  }
+
+  static restore(
+    data: RestoreCreditCardBillDTO,
+  ): Either<DomainError, CreditCardBill> {
+    const either = new Either<DomainError, CreditCardBill>();
+
+    if (data.closingDate >= data.dueDate)
+      either.addError(new InvalidCreditCardBillDateError());
+
+    const creditCardId = EntityId.fromString(data.creditCardId);
+    if (creditCardId.hasError) either.addManyErrors(creditCardId.errors);
+
+    const amount = MoneyVo.create(data.amount);
+    if (amount.hasError) either.addManyErrors(amount.errors);
+
+    const status = BillStatus.create(data.status);
+    if (status.hasError) either.addManyErrors(status.errors);
+
+    const idVo = EntityId.fromString(data.id);
+    if (idVo.hasError) either.addManyErrors(idVo.errors);
+
+    if (either.hasError) return either;
+
+    const bill = new CreditCardBill(
+      creditCardId,
+      data.closingDate,
+      data.dueDate,
+      amount,
+      status,
+      idVo,
+    );
+
+    Object.defineProperty(bill, '_createdAt', {
+      value: data.createdAt,
+      writable: false,
+    });
+    bill._updatedAt = data.updatedAt;
+    bill._paidAt = data.paidAt;
+    bill._isDeleted = data.isDeleted;
+
+    either.setData(bill);
+    return either;
   }
 }

--- a/src/domain/aggregates/credit-card-bill/errors/CreditCardBillAlreadyDeletedError.ts
+++ b/src/domain/aggregates/credit-card-bill/errors/CreditCardBillAlreadyDeletedError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class CreditCardBillAlreadyDeletedError extends DomainError {
+  protected fieldName = 'creditCardBill';
+
+  constructor(message: string = 'Credit card bill is already deleted') {
+    super(message);
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/errors/CreditCardBillAlreadyPaidError.ts
+++ b/src/domain/aggregates/credit-card-bill/errors/CreditCardBillAlreadyPaidError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class CreditCardBillAlreadyPaidError extends DomainError {
+  protected fieldName = 'creditCardBill';
+
+  constructor(message: string = 'Credit card bill is already paid') {
+    super(message);
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/errors/CreditCardBillCannotBeUpdatedError.ts
+++ b/src/domain/aggregates/credit-card-bill/errors/CreditCardBillCannotBeUpdatedError.ts
@@ -1,0 +1,11 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class CreditCardBillCannotBeUpdatedError extends DomainError {
+  protected fieldName = 'creditCardBill';
+
+  constructor(
+    message: string = 'Credit card bill cannot be updated after being paid',
+  ) {
+    super(message);
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/errors/CreditCardBillNotFoundError.ts
+++ b/src/domain/aggregates/credit-card-bill/errors/CreditCardBillNotFoundError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class CreditCardBillNotFoundError extends DomainError {
+  protected fieldName = 'creditCardBill';
+
+  constructor(message: string = 'Credit card bill not found') {
+    super(message);
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/events/CreditCardBillCreatedEvent.ts
+++ b/src/domain/aggregates/credit-card-bill/events/CreditCardBillCreatedEvent.ts
@@ -1,0 +1,15 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+import { BillStatusEnum } from '../value-objects/bill-status/BillStatus';
+
+export class CreditCardBillCreatedEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly creditCardId: string,
+    public readonly closingDate: Date,
+    public readonly dueDate: Date,
+    public readonly amount: number,
+    public readonly status: BillStatusEnum,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/events/CreditCardBillDeletedEvent.ts
+++ b/src/domain/aggregates/credit-card-bill/events/CreditCardBillDeletedEvent.ts
@@ -1,0 +1,10 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+
+export class CreditCardBillDeletedEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly creditCardId: string,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/events/CreditCardBillPaidEvent.ts
+++ b/src/domain/aggregates/credit-card-bill/events/CreditCardBillPaidEvent.ts
@@ -1,0 +1,12 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+
+export class CreditCardBillPaidEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly creditCardId: string,
+    public readonly amount: number,
+    public readonly paidAt: Date,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/events/CreditCardBillReopenedEvent.ts
+++ b/src/domain/aggregates/credit-card-bill/events/CreditCardBillReopenedEvent.ts
@@ -1,0 +1,10 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+
+export class CreditCardBillReopenedEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly creditCardId: string,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/events/CreditCardBillUpdatedEvent.ts
+++ b/src/domain/aggregates/credit-card-bill/events/CreditCardBillUpdatedEvent.ts
@@ -1,0 +1,15 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+import { BillStatusEnum } from '../value-objects/bill-status/BillStatus';
+
+export class CreditCardBillUpdatedEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly creditCardId: string,
+    public readonly closingDate: Date,
+    public readonly dueDate: Date,
+    public readonly amount: number,
+    public readonly status: BillStatusEnum,
+  ) {
+    super(aggregateId);
+  }
+}


### PR DESCRIPTION
## Summary
- add domain events and errors for credit card bill
- implement new behaviors in `CreditCardBill`
- update unit tests for credit card bill entity

## Testing
- `npm test -- -t CreditCardBill --runTestsByPath src/domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill.spec.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ce1ad89488323b6b1ce3846aa95db