### PR TITLE
Implement Category domain features

### DIFF
--- a/src/domain/aggregates/category/category-entity/Category.spec.ts
+++ b/src/domain/aggregates/category/category-entity/Category.spec.ts
@@ -1,8 +1,12 @@
+import { CategoryAlreadyDeletedError } from '../errors/CategoryAlreadyDeletedError';
 import { InvalidCategoryTypeError } from '../errors/InvalidCategoryTypeError';
+import { CategoryCreatedEvent } from '../events/CategoryCreatedEvent';
+import { CategoryDeletedEvent } from '../events/CategoryDeletedEvent';
+import { CategoryUpdatedEvent } from '../events/CategoryUpdatedEvent';
 import { CategoryTypeEnum } from '../value-objects/category-type/CategoryType';
-import { InvalidEntityIdError } from './../../../shared/errors/InvalidEntityIdError';
-import { InvalidEntityNameError } from './../../../shared/errors/InvalidEntityNameError';
-import { EntityId } from './../../../shared/value-objects/entity-id/EntityId';
+import { InvalidEntityIdError } from '../../../shared/errors/InvalidEntityIdError';
+import { InvalidEntityNameError } from '../../../shared/errors/InvalidEntityNameError';
+import { EntityId } from '../../../shared/value-objects/entity-id/EntityId';
 import { Category } from './Category';
 
 function makeCategoryDTO({
@@ -66,6 +70,110 @@ describe('Categoria', () => {
         new InvalidCategoryTypeError(),
         new InvalidEntityIdError(''),
       ]);
+    });
+
+    it('deve emitir CategoryCreatedEvent ao criar', () => {
+      const result = Category.create(makeCategoryDTO());
+      const events = result.data!.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]).toBeInstanceOf(CategoryCreatedEvent);
+    });
+  });
+
+  describe('update', () => {
+    it('deve atualizar e emitir evento', () => {
+      const category = Category.create(makeCategoryDTO()).data!;
+      category.clearEvents();
+
+      const result = category.update({
+        name: 'Novo',
+        type: CategoryTypeEnum.INCOME,
+      });
+
+      expect(result.hasError).toBe(false);
+      expect(category.name).toBe('Novo');
+      expect(category.type).toBe(CategoryTypeEnum.INCOME);
+      expect(category.getEvents()[0]).toBeInstanceOf(CategoryUpdatedEvent);
+    });
+
+    it('não deve emitir evento se nada alterar', () => {
+      const dto = makeCategoryDTO();
+      const category = Category.create(dto).data!;
+      category.clearEvents();
+
+      const result = category.update({ name: dto.name, type: dto.type });
+      expect(result.hasError).toBe(false);
+      expect(category.getEvents()).toHaveLength(0);
+    });
+
+    it('deve retornar erro ao atualizar categoria deletada', () => {
+      const category = Category.create(makeCategoryDTO()).data!;
+      category.delete();
+
+      const result = category.update({
+        name: 'A',
+        type: CategoryTypeEnum.INCOME,
+      });
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(CategoryAlreadyDeletedError);
+    });
+  });
+
+  describe('delete', () => {
+    it('deve deletar e emitir evento', () => {
+      const category = Category.create(makeCategoryDTO()).data!;
+      category.clearEvents();
+
+      const result = category.delete();
+
+      expect(result.hasError).toBe(false);
+      expect(category.isDeleted).toBe(true);
+      expect(category.getEvents()[0]).toBeInstanceOf(CategoryDeletedEvent);
+    });
+
+    it('deve retornar erro se deletar novamente', () => {
+      const category = Category.create(makeCategoryDTO()).data!;
+      category.delete();
+
+      const result = category.delete();
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(CategoryAlreadyDeletedError);
+    });
+  });
+
+  describe('restore', () => {
+    it('deve restaurar categoria', () => {
+      const dto = makeCategoryDTO();
+      const created = Category.create(dto).data!;
+      const data = {
+        id: created.id,
+        name: created.name,
+        type: created.type!,
+        budgetId: created.budgetId,
+        isDeleted: false,
+        createdAt: created.createdAt,
+        updatedAt: created.updatedAt,
+      };
+
+      const result = Category.restore(data);
+      expect(result.hasError).toBe(false);
+      expect(result.data!.id).toBe(created.id);
+      expect(result.data!.getEvents()).toHaveLength(0);
+    });
+  });
+
+  describe('getters', () => {
+    it('deve expor propriedades', () => {
+      const dto = makeCategoryDTO();
+      const category = Category.create(dto).data!;
+
+      expect(category.id).toBeDefined();
+      expect(category.name).toBe(dto.name);
+      expect(category.type).toBe(dto.type);
+      expect(category.budgetId).toBe(dto.budgetId);
+      expect(category.createdAt).toBeInstanceOf(Date);
+      expect(category.updatedAt).toBeInstanceOf(Date);
+      expect(category.isDeleted).toBe(false);
     });
   });
 });

--- a/src/domain/aggregates/category/errors/CategoryAlreadyDeletedError.ts
+++ b/src/domain/aggregates/category/errors/CategoryAlreadyDeletedError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class CategoryAlreadyDeletedError extends DomainError {
+  protected fieldName = 'category';
+
+  constructor(message = 'Category is already deleted') {
+    super(message);
+  }
+}

--- a/src/domain/aggregates/category/errors/CategoryInUseError.ts
+++ b/src/domain/aggregates/category/errors/CategoryInUseError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class CategoryInUseError extends DomainError {
+  protected fieldName = 'category';
+
+  constructor(message = 'Category has related transactions') {
+    super(message);
+  }
+}

--- a/src/domain/aggregates/category/errors/CategoryNotFoundError.ts
+++ b/src/domain/aggregates/category/errors/CategoryNotFoundError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class CategoryNotFoundError extends DomainError {
+  protected fieldName = 'category';
+
+  constructor(message = 'Category not found') {
+    super(message);
+  }
+}

--- a/src/domain/aggregates/category/events/CategoryCreatedEvent.spec.ts
+++ b/src/domain/aggregates/category/events/CategoryCreatedEvent.spec.ts
@@ -1,0 +1,30 @@
+import { CategoryCreatedEvent } from './CategoryCreatedEvent';
+import { CategoryTypeEnum } from '../value-objects/category-type/CategoryType';
+
+describe('CategoryCreatedEvent', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should create event with provided properties', () => {
+    const event = new CategoryCreatedEvent(
+      'cat-id',
+      'Food',
+      CategoryTypeEnum.EXPENSE,
+      'budget-id',
+    );
+
+    expect(event.aggregateId).toBe('cat-id');
+    expect(event.categoryId).toBe('cat-id');
+    expect(event.categoryName).toBe('Food');
+    expect(event.categoryType).toBe(CategoryTypeEnum.EXPENSE);
+    expect(event.budgetId).toBe('budget-id');
+    expect(event.occurredOn).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+    expect(event.eventVersion).toBe(1);
+  });
+});

--- a/src/domain/aggregates/category/events/CategoryCreatedEvent.ts
+++ b/src/domain/aggregates/category/events/CategoryCreatedEvent.ts
@@ -1,0 +1,13 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+import { CategoryTypeEnum } from '../value-objects/category-type/CategoryType';
+
+export class CategoryCreatedEvent extends DomainEvent {
+  constructor(
+    public readonly categoryId: string,
+    public readonly categoryName: string,
+    public readonly categoryType: CategoryTypeEnum,
+    public readonly budgetId: string,
+  ) {
+    super(categoryId);
+  }
+}

--- a/src/domain/aggregates/category/events/CategoryDeletedEvent.spec.ts
+++ b/src/domain/aggregates/category/events/CategoryDeletedEvent.spec.ts
@@ -1,0 +1,22 @@
+import { CategoryDeletedEvent } from './CategoryDeletedEvent';
+
+describe('CategoryDeletedEvent', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-03T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should create event with provided properties', () => {
+    const event = new CategoryDeletedEvent('cat-id', 'Food', 'budget-id');
+
+    expect(event.aggregateId).toBe('cat-id');
+    expect(event.categoryName).toBe('Food');
+    expect(event.budgetId).toBe('budget-id');
+    expect(event.occurredOn).toEqual(new Date('2024-01-03T00:00:00.000Z'));
+    expect(event.eventVersion).toBe(1);
+  });
+});

--- a/src/domain/aggregates/category/events/CategoryDeletedEvent.ts
+++ b/src/domain/aggregates/category/events/CategoryDeletedEvent.ts
@@ -1,0 +1,11 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+
+export class CategoryDeletedEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly categoryName: string,
+    public readonly budgetId: string,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/category/events/CategoryUpdatedEvent.spec.ts
+++ b/src/domain/aggregates/category/events/CategoryUpdatedEvent.spec.ts
@@ -1,0 +1,31 @@
+import { CategoryUpdatedEvent } from './CategoryUpdatedEvent';
+import { CategoryTypeEnum } from '../value-objects/category-type/CategoryType';
+
+describe('CategoryUpdatedEvent', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-02T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should create event with provided properties', () => {
+    const event = new CategoryUpdatedEvent(
+      'cat-id',
+      'Food',
+      'Groceries',
+      CategoryTypeEnum.EXPENSE,
+      CategoryTypeEnum.EXPENSE,
+    );
+
+    expect(event.aggregateId).toBe('cat-id');
+    expect(event.previousName).toBe('Food');
+    expect(event.newName).toBe('Groceries');
+    expect(event.previousType).toBe(CategoryTypeEnum.EXPENSE);
+    expect(event.newType).toBe(CategoryTypeEnum.EXPENSE);
+    expect(event.occurredOn).toEqual(new Date('2024-01-02T00:00:00.000Z'));
+    expect(event.eventVersion).toBe(1);
+  });
+});

--- a/src/domain/aggregates/category/events/CategoryUpdatedEvent.ts
+++ b/src/domain/aggregates/category/events/CategoryUpdatedEvent.ts
@@ -1,0 +1,14 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+import { CategoryTypeEnum } from '../value-objects/category-type/CategoryType';
+
+export class CategoryUpdatedEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly previousName: string,
+    public readonly newName: string,
+    public readonly previousType: CategoryTypeEnum,
+    public readonly newType: CategoryTypeEnum,
+  ) {
+    super(aggregateId);
+  }
+}


### PR DESCRIPTION
## Summary
- complete `Category` entity with audit fields, domain events and restore logic
- add domain errors for category
- implement category domain events and tests
- enhance category entity tests for CRUD operations and events

## Testing
- `npm test -- CategoryCreatedEvent`
- `npm test -- CategoryUpdatedEvent`
- `npm test -- CategoryDeletedEvent`
- `npm test -- Category.spec.ts`
- `npm test -- Category`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cdd76f8888323a6d932724b61a5db