### PR TITLE
Implement UC040 envelope update feature

### DIFF
--- a/src/application/contracts/repositories/envelope/IGetEnvelopeRepository.ts
+++ b/src/application/contracts/repositories/envelope/IGetEnvelopeRepository.ts
@@ -1,0 +1,8 @@
+import { Envelope } from '@domain/aggregates/envelope/envelope-entity/Envelope';
+import { Either } from '@either';
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+
+export interface IGetEnvelopeRepository {
+  execute(id: string): Promise<Either<RepositoryError, Envelope | null>>;
+  existsByName?(budgetId: string, name: string, excludeId?: string): Promise<Either<RepositoryError, boolean>>;
+}

--- a/src/application/contracts/repositories/envelope/IUpdateEnvelopeRepository.ts
+++ b/src/application/contracts/repositories/envelope/IUpdateEnvelopeRepository.ts
@@ -1,0 +1,7 @@
+import { Envelope } from '@domain/aggregates/envelope/envelope-entity/Envelope';
+import { Either } from '@either';
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+
+export interface IUpdateEnvelopeRepository {
+  execute(envelope: Envelope): Promise<Either<RepositoryError, void>>;
+}

--- a/src/application/shared/errors/DuplicateEnvelopeNameError.ts
+++ b/src/application/shared/errors/DuplicateEnvelopeNameError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class DuplicateEnvelopeNameError extends ApplicationError {
+  constructor() {
+    super('Envelope name already exists');
+  }
+}

--- a/src/application/shared/errors/EnvelopeNotFoundError.ts
+++ b/src/application/shared/errors/EnvelopeNotFoundError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class EnvelopeNotFoundError extends ApplicationError {
+  constructor() {
+    super('Envelope not found');
+  }
+}

--- a/src/application/shared/errors/EnvelopePersistenceFailedError.ts
+++ b/src/application/shared/errors/EnvelopePersistenceFailedError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class EnvelopePersistenceFailedError extends ApplicationError {
+  constructor() {
+    super('Failed to persist envelope');
+  }
+}

--- a/src/application/shared/errors/EnvelopeRepositoryError.ts
+++ b/src/application/shared/errors/EnvelopeRepositoryError.ts
@@ -1,0 +1,8 @@
+import { ApplicationError } from './ApplicationError';
+
+export class EnvelopeRepositoryError extends ApplicationError {
+  constructor() {
+    super('Failed to find envelope');
+    this.name = 'EnvelopeRepositoryError';
+  }
+}

--- a/src/application/shared/errors/EnvelopeUpdateFailedError.ts
+++ b/src/application/shared/errors/EnvelopeUpdateFailedError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class EnvelopeUpdateFailedError extends ApplicationError {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/application/shared/errors/NoFieldsToUpdateError.ts
+++ b/src/application/shared/errors/NoFieldsToUpdateError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class NoFieldsToUpdateError extends ApplicationError {
+  constructor() {
+    super('No fields provided to update');
+  }
+}

--- a/src/application/use-cases/envelope/update-envelope/UpdateEnvelopeDto.ts
+++ b/src/application/use-cases/envelope/update-envelope/UpdateEnvelopeDto.ts
@@ -1,0 +1,11 @@
+export interface UpdateEnvelopeDto {
+  userId: string;
+  budgetId: string;
+  envelopeId: string;
+  name?: string;
+  description?: string;
+  monthlyAllocation?: number;
+  associatedCategories?: string[];
+  color?: string;
+  icon?: string;
+}

--- a/src/application/use-cases/envelope/update-envelope/UpdateEnvelopeUseCase.spec.ts
+++ b/src/application/use-cases/envelope/update-envelope/UpdateEnvelopeUseCase.spec.ts
@@ -1,0 +1,154 @@
+import { Envelope } from '@domain/aggregates/envelope/envelope-entity/Envelope';
+import { EnvelopeUpdatedEvent } from '@domain/aggregates/envelope/events/EnvelopeUpdatedEvent';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { Either } from '@either';
+import { UpdateEnvelopeUseCase } from './UpdateEnvelopeUseCase';
+import { UpdateEnvelopeDto } from './UpdateEnvelopeDto';
+import { IGetEnvelopeRepository } from '../../../contracts/repositories/envelope/IGetEnvelopeRepository';
+import { IUpdateEnvelopeRepository } from '../../../contracts/repositories/envelope/IUpdateEnvelopeRepository';
+import { EnvelopeNotFoundError } from '../../../shared/errors/EnvelopeNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { DuplicateEnvelopeNameError } from '../../../shared/errors/DuplicateEnvelopeNameError';
+import { NoFieldsToUpdateError } from '../../../shared/errors/NoFieldsToUpdateError';
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+
+class GetEnvelopeRepositoryStub implements IGetEnvelopeRepository {
+  public shouldFail = false;
+  public shouldReturnNull = false;
+  public exists = false;
+  public executeCalls: string[] = [];
+
+  constructor(public mockEnvelope: Envelope) {}
+
+  async execute(id: string): Promise<Either<RepositoryError, Envelope | null>> {
+    this.executeCalls.push(id);
+    if (this.shouldFail) return Either.error(new RepositoryError('fail'));
+    if (this.shouldReturnNull) return Either.success(null);
+    return Either.success(this.mockEnvelope);
+  }
+
+  async existsByName(
+    _budgetId: string,
+    _name: string,
+    _excludeId?: string,
+  ): Promise<Either<RepositoryError, boolean>> {
+    return Either.success(this.exists);
+  }
+}
+
+class UpdateEnvelopeRepositoryStub implements IUpdateEnvelopeRepository {
+  public shouldFail = false;
+  public executeCalls: Envelope[] = [];
+  async execute(
+    envelope: Envelope,
+  ): Promise<Either<RepositoryError, void>> {
+    this.executeCalls.push(envelope);
+    if (this.shouldFail) return Either.error(new RepositoryError('fail'));
+    return Either.success();
+  }
+}
+
+describe('UpdateEnvelopeUseCase', () => {
+  let envelope: Envelope;
+  let getRepo: GetEnvelopeRepositoryStub;
+  let updateRepo: UpdateEnvelopeRepositoryStub;
+  let authService: BudgetAuthorizationServiceStub;
+  let publisher: EventPublisherStub;
+  let useCase: UpdateEnvelopeUseCase;
+  let budgetId: string;
+
+  beforeEach(() => {
+    budgetId = EntityId.create().value!.id;
+    const result = Envelope.create({
+      budgetId,
+      name: 'Food',
+      monthlyAllocation: 1000,
+      associatedCategories: [],
+    });
+    if (result.hasError) throw new Error('invalid');
+    envelope = result.data!;
+    envelope.clearEvents();
+
+    getRepo = new GetEnvelopeRepositoryStub(envelope);
+    updateRepo = new UpdateEnvelopeRepositoryStub();
+    authService = new BudgetAuthorizationServiceStub();
+    publisher = new EventPublisherStub();
+    useCase = new UpdateEnvelopeUseCase(getRepo, updateRepo, authService, publisher);
+  });
+
+  it('should update name successfully', async () => {
+    const dto: UpdateEnvelopeDto = {
+      userId: 'user',
+      budgetId,
+      envelopeId: envelope.id,
+      name: 'Groceries',
+    };
+
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(false);
+    expect(result.data!.id).toBe(envelope.id);
+  });
+
+  it('should validate duplicate name', async () => {
+    getRepo.exists = true;
+    const dto: UpdateEnvelopeDto = {
+      userId: 'user',
+      budgetId,
+      envelopeId: envelope.id,
+      name: 'Groceries',
+    };
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(DuplicateEnvelopeNameError);
+  });
+
+  it('should return error when no fields provided', async () => {
+    const dto: UpdateEnvelopeDto = {
+      userId: 'user',
+      budgetId,
+      envelopeId: envelope.id,
+    };
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(NoFieldsToUpdateError);
+  });
+
+  it('should return error if envelope not found', async () => {
+    getRepo.shouldReturnNull = true;
+    const dto: UpdateEnvelopeDto = {
+      userId: 'user',
+      budgetId,
+      envelopeId: envelope.id,
+      name: 'Groceries',
+    };
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(EnvelopeNotFoundError);
+  });
+
+  it('should return error when user has no permission', async () => {
+    authService.mockHasAccess = false;
+    const dto: UpdateEnvelopeDto = {
+      userId: 'user',
+      budgetId,
+      envelopeId: envelope.id,
+      name: 'Groceries',
+    };
+    const result = await useCase.execute(dto);
+    expect(result.errors[0]).toBeInstanceOf(InsufficientPermissionsError);
+  });
+
+  it('should publish event after update', async () => {
+    const dto: UpdateEnvelopeDto = {
+      userId: 'user',
+      budgetId,
+      envelopeId: envelope.id,
+      name: 'Groceries',
+    };
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(false);
+    expect(publisher.publishManyCalls[0][0]).toBeInstanceOf(EnvelopeUpdatedEvent);
+  });
+});

--- a/src/application/use-cases/envelope/update-envelope/UpdateEnvelopeUseCase.ts
+++ b/src/application/use-cases/envelope/update-envelope/UpdateEnvelopeUseCase.ts
@@ -1,0 +1,87 @@
+import { Envelope } from '@domain/aggregates/envelope/envelope-entity/Envelope';
+import { Either } from '@either';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { IUseCase } from '../../../shared/IUseCase';
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IGetEnvelopeRepository } from '../../../contracts/repositories/envelope/IGetEnvelopeRepository';
+import { IUpdateEnvelopeRepository } from '../../../contracts/repositories/envelope/IUpdateEnvelopeRepository';
+import { UpdateEnvelopeDto } from './UpdateEnvelopeDto';
+import { EnvelopeNotFoundError } from '../../../shared/errors/EnvelopeNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { EnvelopeRepositoryError } from '../../../shared/errors/EnvelopeRepositoryError';
+import { EnvelopePersistenceFailedError } from '../../../shared/errors/EnvelopePersistenceFailedError';
+import { DuplicateEnvelopeNameError } from '../../../shared/errors/DuplicateEnvelopeNameError';
+import { NoFieldsToUpdateError } from '../../../shared/errors/NoFieldsToUpdateError';
+import { EnvelopeUpdateFailedError } from '../../../shared/errors/EnvelopeUpdateFailedError';
+
+export class UpdateEnvelopeUseCase implements IUseCase<UpdateEnvelopeDto> {
+  constructor(
+    private readonly getEnvelopeRepository: IGetEnvelopeRepository,
+    private readonly updateEnvelopeRepository: IUpdateEnvelopeRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(dto: UpdateEnvelopeDto): Promise<Either<ApplicationError, { id: string }>> {
+    const envelopeResult = await this.getEnvelopeRepository.execute(dto.envelopeId);
+    if (envelopeResult.hasError) {
+      return Either.error(new EnvelopeRepositoryError());
+    }
+
+    const envelope = envelopeResult.data;
+    if (!envelope) {
+      return Either.error(new EnvelopeNotFoundError());
+    }
+
+    const auth = await this.budgetAuthorizationService.canAccessBudget(dto.userId, envelope.budgetId);
+    if (auth.hasError) return Either.errors(auth.errors);
+    if (!auth.data) return Either.error(new InsufficientPermissionsError());
+
+    if (
+      dto.name === undefined &&
+      dto.description === undefined &&
+      dto.monthlyAllocation === undefined &&
+      dto.associatedCategories === undefined &&
+      dto.color === undefined &&
+      dto.icon === undefined
+    ) {
+      return Either.error(new NoFieldsToUpdateError());
+    }
+
+    if (dto.name && dto.name !== envelope.name && this.getEnvelopeRepository.existsByName) {
+      const existsResult = await this.getEnvelopeRepository.existsByName(dto.budgetId, dto.name, envelope.id);
+      if (existsResult.hasError) return Either.error(new EnvelopeRepositoryError());
+      if (existsResult.data) return Either.error(new DuplicateEnvelopeNameError());
+    }
+
+    const updateResult = envelope.update({
+      name: dto.name,
+      description: dto.description,
+      monthlyAllocation: dto.monthlyAllocation,
+      associatedCategories: dto.associatedCategories,
+      color: dto.color,
+      icon: dto.icon,
+    });
+
+    if (updateResult.hasError) {
+      const errorMessage = updateResult.errors.map((e) => e.message).join('; ');
+      return Either.error(new EnvelopeUpdateFailedError(errorMessage));
+    }
+
+    const persist = await this.updateEnvelopeRepository.execute(envelope);
+    if (persist.hasError) return Either.error(new EnvelopePersistenceFailedError());
+
+    const events = envelope.getEvents();
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        envelope.clearEvents();
+      } catch (e) {
+        console.error('Failed to publish events:', e);
+      }
+    }
+
+    return Either.success({ id: envelope.id });
+  }
+}

--- a/src/domain/aggregates/envelope/envelope-entity/Envelope.spec.ts
+++ b/src/domain/aggregates/envelope/envelope-entity/Envelope.spec.ts
@@ -1,0 +1,41 @@
+import { Envelope } from './Envelope';
+import { EntityId } from '../../../shared/value-objects/entity-id/EntityId';
+import { EnvelopeUpdatedEvent } from '../events/EnvelopeUpdatedEvent';
+
+describe('Envelope.update', () => {
+  const createEnvelope = () => {
+    const result = Envelope.create({
+      budgetId: EntityId.create().value!.id,
+      name: 'Groceries',
+      monthlyAllocation: 1000,
+      associatedCategories: [EntityId.create().value!.id],
+    });
+    if (result.hasError) throw new Error('invalid envelope');
+    const env = result.data!;
+    env.clearEvents();
+    return env;
+  };
+
+  it('should update name and emit event', () => {
+    const env = createEnvelope();
+    const res = env.update({ name: 'Food' });
+    expect(res.hasError).toBe(false);
+    expect(env.name).toBe('Food');
+    const events = env.getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toBeInstanceOf(EnvelopeUpdatedEvent);
+  });
+
+  it('should not emit event if nothing changed', () => {
+    const env = createEnvelope();
+    const res = env.update({});
+    expect(res.hasError).toBe(false);
+    expect(env.getEvents()).toHaveLength(0);
+  });
+
+  it('should accumulate errors for invalid data', () => {
+    const env = createEnvelope();
+    const res = env.update({ name: '' });
+    expect(res.hasError).toBe(true);
+  });
+});

--- a/src/domain/aggregates/envelope/envelope-entity/Envelope.ts
+++ b/src/domain/aggregates/envelope/envelope-entity/Envelope.ts
@@ -1,0 +1,241 @@
+import { AggregateRoot } from '../../../shared/AggregateRoot';
+import { DomainError } from '../../../shared/DomainError';
+import { IEntity } from '../../../shared/IEntity';
+import { EntityId } from '../../../shared/value-objects/entity-id/EntityId';
+import { EntityName } from '../../../shared/value-objects/entity-name/EntityName';
+import { MoneyVo } from '../../../shared/value-objects/money-vo/MoneyVo';
+import { BalanceVo } from '../../../shared/value-objects/balance-vo/BalanceVo';
+import { Either } from '@either';
+import { EnvelopeUpdatedEvent } from '../events/EnvelopeUpdatedEvent';
+
+export interface CreateEnvelopeDTO {
+  budgetId: string;
+  name: string;
+  description?: string;
+  monthlyAllocation: number;
+  associatedCategories?: string[];
+  color?: string;
+  icon?: string;
+}
+
+export interface UpdateEnvelopeDTO {
+  name?: string;
+  description?: string;
+  monthlyAllocation?: number;
+  associatedCategories?: string[];
+  color?: string;
+  icon?: string;
+}
+
+export class Envelope extends AggregateRoot implements IEntity {
+  private readonly _id: EntityId;
+  private readonly _budgetId: EntityId;
+  private readonly _createdAt: Date;
+  private _updatedAt: Date;
+  private _name: EntityName;
+  private _description?: string;
+  private _monthlyAllocation: MoneyVo;
+  private _balance: BalanceVo;
+  private _associatedCategories: EntityId[];
+  private _color?: string;
+  private _icon?: string;
+
+  private constructor(
+    budgetId: EntityId,
+    name: EntityName,
+    monthlyAllocation: MoneyVo,
+    balance: BalanceVo,
+    associatedCategories: EntityId[],
+    description?: string,
+    color?: string,
+    icon?: string,
+    existingId?: EntityId,
+  ) {
+    super();
+    this._id = existingId || EntityId.create();
+    this._budgetId = budgetId;
+    this._name = name;
+    this._monthlyAllocation = monthlyAllocation;
+    this._balance = balance;
+    this._associatedCategories = associatedCategories;
+    this._description = description;
+    this._color = color;
+    this._icon = icon;
+    this._createdAt = new Date();
+    this._updatedAt = new Date();
+  }
+
+  get id(): string {
+    return this._id.value!.id;
+  }
+
+  get budgetId(): string {
+    return this._budgetId.value!.id;
+  }
+
+  get name(): string {
+    return this._name.value!.name;
+  }
+
+  get description(): string | undefined {
+    return this._description;
+  }
+
+  get monthlyAllocation(): number {
+    return this._monthlyAllocation.value!.cents;
+  }
+
+  get balance(): number {
+    return this._balance.value!.cents;
+  }
+
+  get associatedCategories(): string[] {
+    return this._associatedCategories.map((c) => c.value!.id);
+  }
+
+  get color(): string | undefined {
+    return this._color;
+  }
+
+  get icon(): string | undefined {
+    return this._icon;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+
+  static create(data: CreateEnvelopeDTO): Either<DomainError, Envelope> {
+    const either = new Either<DomainError, Envelope>();
+
+    const budgetIdVo = EntityId.fromString(data.budgetId);
+    if (budgetIdVo.hasError) either.addManyErrors(budgetIdVo.errors);
+
+    const nameVo = EntityName.create(data.name);
+    if (nameVo.hasError) either.addManyErrors(nameVo.errors);
+
+    const allocationVo = MoneyVo.create(data.monthlyAllocation);
+    if (allocationVo.hasError) either.addManyErrors(allocationVo.errors);
+
+    const associated: EntityId[] = [];
+    if (data.associatedCategories) {
+      for (const id of data.associatedCategories) {
+        const vo = EntityId.fromString(id);
+        if (vo.hasError) {
+          either.addManyErrors(vo.errors);
+        } else {
+          associated.push(vo);
+        }
+      }
+    }
+
+    if (either.hasError) return either;
+
+    const balanceVo = BalanceVo.create(0);
+    const envelope = new Envelope(
+      budgetIdVo,
+      nameVo,
+      allocationVo,
+      balanceVo,
+      associated,
+      data.description,
+      data.color,
+      data.icon,
+    );
+    either.setData(envelope);
+    return either;
+  }
+
+  update(data: UpdateEnvelopeDTO): Either<DomainError, void> {
+    const either = new Either<DomainError, void>();
+
+    let nameVo: EntityName | undefined;
+    if (data.name !== undefined) {
+      nameVo = EntityName.create(data.name);
+      if (nameVo.hasError) either.addManyErrors(nameVo.errors);
+    }
+
+    let allocationVo: MoneyVo | undefined;
+    if (data.monthlyAllocation !== undefined) {
+      allocationVo = MoneyVo.create(data.monthlyAllocation);
+      if (allocationVo.hasError) either.addManyErrors(allocationVo.errors);
+    }
+
+    const categories: EntityId[] = [];
+    let categoriesChanged = false;
+    if (data.associatedCategories !== undefined) {
+      for (const id of data.associatedCategories) {
+        const vo = EntityId.fromString(id);
+        if (vo.hasError) {
+          either.addManyErrors(vo.errors);
+        } else {
+          categories.push(vo);
+        }
+      }
+      categoriesChanged = true;
+    }
+
+    if (either.hasError) return either;
+
+    const nameChanged =
+      nameVo !== undefined && nameVo.value!.name !== this._name.value!.name;
+    const descChanged =
+      data.description !== undefined && data.description !== this._description;
+    const allocationChanged =
+      allocationVo !== undefined &&
+      allocationVo.value!.cents !== this._monthlyAllocation.value!.cents;
+    const colorChanged = data.color !== undefined && data.color !== this._color;
+    const iconChanged = data.icon !== undefined && data.icon !== this._icon;
+    if (
+      !nameChanged &&
+      !descChanged &&
+      !allocationChanged &&
+      !categoriesChanged &&
+      !colorChanged &&
+      !iconChanged
+    ) {
+      return Either.success();
+    }
+
+    const prevName = this.name;
+    const prevDesc = this._description;
+    const prevAlloc = this.monthlyAllocation;
+    const prevCats = this.associatedCategories;
+    const prevColor = this._color;
+    const prevIcon = this._icon;
+
+    if (nameChanged && nameVo) this._name = nameVo;
+    if (descChanged) this._description = data.description;
+    if (allocationChanged && allocationVo) this._monthlyAllocation = allocationVo;
+    if (categoriesChanged) this._associatedCategories = categories;
+    if (colorChanged) this._color = data.color;
+    if (iconChanged) this._icon = data.icon;
+
+    this._updatedAt = new Date();
+
+    this.addEvent(
+      new EnvelopeUpdatedEvent(
+        this.id,
+        this.budgetId,
+        prevName,
+        this.name,
+        prevDesc,
+        this._description,
+        prevAlloc,
+        this.monthlyAllocation,
+        prevCats,
+        this.associatedCategories,
+        prevColor,
+        this._color,
+        prevIcon,
+        this._icon,
+      ),
+    );
+
+    return Either.success();
+  }
+}

--- a/src/domain/aggregates/envelope/events/EnvelopeUpdatedEvent.ts
+++ b/src/domain/aggregates/envelope/events/EnvelopeUpdatedEvent.ts
@@ -1,0 +1,22 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+
+export class EnvelopeUpdatedEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly budgetId: string,
+    public readonly previousName: string,
+    public readonly newName: string,
+    public readonly previousDescription: string | undefined,
+    public readonly newDescription: string | undefined,
+    public readonly previousMonthlyAllocation: number,
+    public readonly newMonthlyAllocation: number,
+    public readonly previousCategories: string[],
+    public readonly newCategories: string[],
+    public readonly previousColor?: string,
+    public readonly newColor?: string,
+    public readonly previousIcon?: string,
+    public readonly newIcon?: string,
+  ) {
+    super(aggregateId);
+  }
+}


### PR DESCRIPTION
## Summary
- add envelope aggregate with update capability
- emit `EnvelopeUpdatedEvent` when editing envelopes
- implement update envelope use case with validations
- add repository interfaces and related errors
- provide unit tests for entity and use case

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d3927f8d08323b5948053479b48c6