### PR TITLE
Implement UC038 automatic contribution

### DIFF
--- a/src/application/contracts/repositories/goal/IConfigureAutomaticContributionRepository.ts
+++ b/src/application/contracts/repositories/goal/IConfigureAutomaticContributionRepository.ts
@@ -1,0 +1,7 @@
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { Goal } from '@domain/aggregates/goal/goal-entity/Goal';
+import { Either } from '@either';
+
+export interface IConfigureAutomaticContributionRepository {
+  execute(goal: Goal): Promise<Either<RepositoryError, void>>;
+}

--- a/src/application/shared/errors/AutomaticContributionAlreadyConfiguredError.ts
+++ b/src/application/shared/errors/AutomaticContributionAlreadyConfiguredError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class AutomaticContributionAlreadyConfiguredError extends ApplicationError {
+  constructor() {
+    super('Automatic contribution already configured');
+  }
+}

--- a/src/application/shared/errors/GoalNotActiveError.ts
+++ b/src/application/shared/errors/GoalNotActiveError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class GoalNotActiveError extends ApplicationError {
+  constructor() {
+    super('Goal is not active');
+  }
+}

--- a/src/application/shared/errors/InvalidContributionAmountError.ts
+++ b/src/application/shared/errors/InvalidContributionAmountError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class InvalidContributionAmountError extends ApplicationError {
+  constructor() {
+    super('Invalid contribution amount');
+  }
+}

--- a/src/application/shared/errors/InvalidFrequencyConfigurationError.ts
+++ b/src/application/shared/errors/InvalidFrequencyConfigurationError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class InvalidFrequencyConfigurationError extends ApplicationError {
+  constructor() {
+    super('Invalid frequency configuration');
+  }
+}

--- a/src/application/shared/errors/InvalidStartDateError.ts
+++ b/src/application/shared/errors/InvalidStartDateError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class InvalidStartDateError extends ApplicationError {
+  constructor() {
+    super('Invalid start date');
+  }
+}

--- a/src/application/shared/tests/stubs/ConfigureAutomaticContributionRepositoryStub.ts
+++ b/src/application/shared/tests/stubs/ConfigureAutomaticContributionRepositoryStub.ts
@@ -1,0 +1,18 @@
+import { Goal } from '@domain/aggregates/goal/goal-entity/Goal';
+import { Either } from '@either';
+
+import { IConfigureAutomaticContributionRepository } from '../../../contracts/repositories/goal/IConfigureAutomaticContributionRepository';
+import { RepositoryError } from '../../errors/RepositoryError';
+
+export class ConfigureAutomaticContributionRepositoryStub implements IConfigureAutomaticContributionRepository {
+  public shouldFail = false;
+  public executeCalls: Goal[] = [];
+
+  async execute(goal: Goal): Promise<Either<RepositoryError, void>> {
+    this.executeCalls.push(goal);
+    if (this.shouldFail) {
+      return Either.error(new RepositoryError('Repository failure'));
+    }
+    return Either.success();
+  }
+}

--- a/src/application/use-cases/goal/configure-automatic-contribution/ConfigureAutomaticContributionDto.ts
+++ b/src/application/use-cases/goal/configure-automatic-contribution/ConfigureAutomaticContributionDto.ts
@@ -1,0 +1,14 @@
+import { FrequencyType } from '@domain/aggregates/goal/enums/FrequencyType';
+
+export interface ConfigureAutomaticContributionDto {
+  userId: string;
+  budgetId: string;
+  goalId: string;
+  contributionAmount: number;
+  frequencyType: FrequencyType;
+  executionDay: number;
+  sourceAccountId: string;
+  startDate: string;
+  endDate?: string;
+  isActive: boolean;
+}

--- a/src/application/use-cases/goal/configure-automatic-contribution/ConfigureAutomaticContributionUseCase.spec.ts
+++ b/src/application/use-cases/goal/configure-automatic-contribution/ConfigureAutomaticContributionUseCase.spec.ts
@@ -1,0 +1,110 @@
+import { Goal } from '@domain/aggregates/goal/goal-entity/Goal';
+import { FrequencyType } from '@domain/aggregates/goal/enums/FrequencyType';
+
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { GoalNotFoundError } from '../../../shared/errors/GoalNotFoundError';
+import { GoalNotActiveError } from '../../../shared/errors/GoalNotActiveError';
+import { InvalidContributionAmountError } from '../../../shared/errors/InvalidContributionAmountError';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetGoalByIdRepositoryStub } from '../../../shared/tests/stubs/GetGoalByIdRepositoryStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { ConfigureAutomaticContributionRepositoryStub } from '../../../shared/tests/stubs/ConfigureAutomaticContributionRepositoryStub';
+import { ConfigureAutomaticContributionDto } from './ConfigureAutomaticContributionDto';
+import { ConfigureAutomaticContributionUseCase } from './ConfigureAutomaticContributionUseCase';
+
+const makeGoal = (): Goal => {
+  const goalResult = Goal.create({
+    name: 'Meta Teste',
+    totalAmount: 1000,
+    budgetId: '550e8400-e29b-41d4-a716-446655440001',
+  });
+  return goalResult.data!;
+};
+
+describe('ConfigureAutomaticContributionUseCase', () => {
+  let useCase: ConfigureAutomaticContributionUseCase;
+  let getGoalRepository: GetGoalByIdRepositoryStub;
+  let getAccountRepository: GetAccountRepositoryStub;
+  let configureRepository: ConfigureAutomaticContributionRepositoryStub;
+  let budgetAuthService: BudgetAuthorizationServiceStub;
+  let eventPublisher: EventPublisherStub;
+  let validGoal: Goal;
+  const userId = 'user-1';
+  const accountId = '550e8400-e29b-41d4-a716-446655440002';
+
+  beforeEach(() => {
+    getGoalRepository = new GetGoalByIdRepositoryStub();
+    getAccountRepository = new GetAccountRepositoryStub();
+    configureRepository = new ConfigureAutomaticContributionRepositoryStub();
+    budgetAuthService = new BudgetAuthorizationServiceStub();
+    eventPublisher = new EventPublisherStub();
+    useCase = new ConfigureAutomaticContributionUseCase(
+      getGoalRepository,
+      getAccountRepository,
+      configureRepository,
+      budgetAuthService,
+      eventPublisher,
+    );
+
+    validGoal = makeGoal();
+    validGoal.clearEvents();
+    getGoalRepository.mockGoal = validGoal;
+    getAccountRepository.mockAccount = {
+      ...({} as any),
+      id: accountId,
+      budgetId: validGoal.budgetId,
+    } as any;
+    budgetAuthService.mockHasAccess = true;
+  });
+
+  const makeDto = (): ConfigureAutomaticContributionDto => ({
+    userId,
+    budgetId: validGoal.budgetId,
+    goalId: validGoal.id,
+    contributionAmount: 100,
+    frequencyType: FrequencyType.MONTHLY,
+    executionDay: 10,
+    sourceAccountId: accountId,
+    startDate: new Date(Date.now() + 86400000).toISOString(),
+    isActive: true,
+  });
+
+  it('deve configurar aporte com sucesso', async () => {
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(false);
+  });
+
+  it('deve falhar se meta não encontrada', async () => {
+    getGoalRepository.setGoal(null);
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new GoalNotFoundError());
+  });
+
+  it('deve falhar se conta não encontrada', async () => {
+    getAccountRepository.shouldReturnNull = true;
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new AccountNotFoundError());
+  });
+
+  it('deve falhar se meta inativa', async () => {
+    validGoal.delete();
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new GoalNotActiveError());
+  });
+
+  it('deve falhar se valor inválido', async () => {
+    const dto = makeDto();
+    dto.contributionAmount = 0;
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(InvalidContributionAmountError);
+  });
+});

--- a/src/application/use-cases/goal/configure-automatic-contribution/ConfigureAutomaticContributionUseCase.ts
+++ b/src/application/use-cases/goal/configure-automatic-contribution/ConfigureAutomaticContributionUseCase.ts
@@ -1,0 +1,141 @@
+import { Goal } from '@domain/aggregates/goal/goal-entity/Goal';
+import { AutomaticContribution } from '@domain/aggregates/goal/value-objects/automatic-contribution/AutomaticContribution';
+import { ContributionFrequency } from '@domain/aggregates/goal/value-objects/contribution-frequency/ContributionFrequency';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IGetGoalByIdRepository } from '../../../contracts/repositories/goal/IGetGoalByIdRepository';
+import { IGetAccountRepository } from '../../../contracts/repositories/account/IGetAccountRepository';
+import { IConfigureAutomaticContributionRepository } from '../../../contracts/repositories/goal/IConfigureAutomaticContributionRepository';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { GoalNotFoundError } from '../../../shared/errors/GoalNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+import { GoalNotActiveError } from '../../../shared/errors/GoalNotActiveError';
+import { InvalidContributionAmountError } from '../../../shared/errors/InvalidContributionAmountError';
+import { InvalidContributionAmountError as DomainInvalidContributionAmountError } from '@domain/aggregates/goal/errors/InvalidContributionAmountError';
+import { InvalidFrequencyConfigurationError } from '../../../shared/errors/InvalidFrequencyConfigurationError';
+import { InvalidStartDateError } from '../../../shared/errors/InvalidStartDateError';
+import { InvalidStartDateError as DomainInvalidStartDateError } from '@domain/aggregates/goal/errors/InvalidStartDateError';
+import { AutomaticContributionAlreadyConfiguredError } from '../../../shared/errors/AutomaticContributionAlreadyConfiguredError';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+import { ConfigureAutomaticContributionDto } from './ConfigureAutomaticContributionDto';
+
+export class ConfigureAutomaticContributionUseCase
+  implements IUseCase<ConfigureAutomaticContributionDto>
+{
+  constructor(
+    private readonly getGoalRepository: IGetGoalByIdRepository,
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly configureRepository: IConfigureAutomaticContributionRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(
+    dto: ConfigureAutomaticContributionDto,
+  ): Promise<Either<DomainError | ApplicationError, UseCaseResponse>> {
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      dto.budgetId,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors(authResult.errors);
+    }
+
+    if (!authResult.data) {
+      return Either.error(new InsufficientPermissionsError());
+    }
+
+    const goalResult = await this.getGoalRepository.execute(dto.goalId);
+
+    if (goalResult.hasError) {
+      return Either.errors(goalResult.errors);
+    }
+
+    const goal = goalResult.data;
+    if (!goal) {
+      return Either.error(new GoalNotFoundError());
+    }
+
+    if (goal.isDeleted || goal.isAchieved()) {
+      return Either.error(new GoalNotActiveError());
+    }
+
+    const accountResult = await this.getAccountRepository.execute(
+      dto.sourceAccountId,
+    );
+
+    if (accountResult.hasError) {
+      return Either.errors([new RepositoryError('account')]);
+    }
+
+    if (!accountResult.data) {
+      return Either.error(new AccountNotFoundError());
+    }
+
+    const frequency = ContributionFrequency.create({
+      type: dto.frequencyType,
+      executionDay: dto.executionDay,
+      interval: 1,
+      startDate: new Date(dto.startDate),
+    });
+
+    if (frequency.hasError) {
+      return Either.errors<DomainError | ApplicationError, UseCaseResponse>([
+        new InvalidFrequencyConfigurationError(),
+      ]);
+    }
+
+    const contribution = AutomaticContribution.create({
+      amount: dto.contributionAmount,
+      frequency,
+      sourceAccountId: dto.sourceAccountId,
+      startDate: new Date(dto.startDate),
+      endDate: dto.endDate ? new Date(dto.endDate) : undefined,
+      isActive: dto.isActive,
+    });
+
+    if (contribution.hasError) {
+      const err = contribution.errors[0];
+      if (
+        err instanceof DomainInvalidContributionAmountError ||
+        err instanceof InvalidContributionAmountError
+      )
+        return Either.error(new InvalidContributionAmountError());
+      if (
+        err instanceof DomainInvalidStartDateError ||
+        err instanceof InvalidStartDateError
+      )
+        return Either.error(new InvalidStartDateError());
+      return Either.errors(contribution.errors);
+    }
+
+    const configResult = goal.configureAutomaticContribution(contribution);
+    if (configResult.hasError) {
+      const first = configResult.errors[0];
+      if (first instanceof AutomaticContributionAlreadyConfiguredError)
+        return Either.error(first);
+      return Either.errors(configResult.errors);
+    }
+
+    const persistResult = await this.configureRepository.execute(goal);
+
+    if (persistResult.hasError) {
+      return Either.errors(persistResult.errors);
+    }
+
+    try {
+      await this.eventPublisher.publishMany(goal.getEvents());
+      goal.clearEvents();
+    } catch (error) {
+      console.error('Failed to publish events:', error);
+    }
+
+    return Either.success({ id: goal.id });
+  }
+}

--- a/src/domain/aggregates/goal/enums/FrequencyType.ts
+++ b/src/domain/aggregates/goal/enums/FrequencyType.ts
@@ -1,0 +1,5 @@
+export enum FrequencyType {
+  WEEKLY = 'WEEKLY',
+  MONTHLY = 'MONTHLY',
+  YEARLY = 'YEARLY',
+}

--- a/src/domain/aggregates/goal/errors/AutomaticContributionAlreadyConfiguredError.ts
+++ b/src/domain/aggregates/goal/errors/AutomaticContributionAlreadyConfiguredError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class AutomaticContributionAlreadyConfiguredError extends DomainError {
+  constructor() {
+    super('Automatic contribution already configured');
+  }
+}

--- a/src/domain/aggregates/goal/errors/InvalidContributionAmountError.ts
+++ b/src/domain/aggregates/goal/errors/InvalidContributionAmountError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidContributionAmountError extends DomainError {
+  constructor() {
+    super('Invalid contribution amount');
+  }
+}

--- a/src/domain/aggregates/goal/errors/InvalidFrequencyConfigurationError.ts
+++ b/src/domain/aggregates/goal/errors/InvalidFrequencyConfigurationError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidFrequencyConfigurationError extends DomainError {
+  constructor() {
+    super('Invalid frequency configuration');
+  }
+}

--- a/src/domain/aggregates/goal/errors/InvalidStartDateError.ts
+++ b/src/domain/aggregates/goal/errors/InvalidStartDateError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidStartDateError extends DomainError {
+  constructor() {
+    super('Invalid start date');
+  }
+}

--- a/src/domain/aggregates/goal/events/AutomaticContributionConfiguredEvent.ts
+++ b/src/domain/aggregates/goal/events/AutomaticContributionConfiguredEvent.ts
@@ -1,0 +1,14 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+import { FrequencyType } from '../enums/FrequencyType';
+
+export class AutomaticContributionConfiguredEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly contributionAmount: number,
+    public readonly frequencyType: FrequencyType,
+    public readonly executionDay: number,
+    public readonly nextExecutionDate: Date,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/goal/goal-entity/Goal.spec.ts
+++ b/src/domain/aggregates/goal/goal-entity/Goal.spec.ts
@@ -5,6 +5,10 @@ import { Goal } from './Goal';
 import { GoalAlreadyDeletedError } from '../errors/GoalAlreadyDeletedError';
 import { GoalAlreadyAchievedError } from '../errors/GoalAlreadyAchievedError';
 import { InvalidGoalAmountError } from '../errors/InvalidGoalAmountError';
+import { ContributionFrequency } from '../value-objects/contribution-frequency/ContributionFrequency';
+import { FrequencyType } from '../enums/FrequencyType';
+import { AutomaticContribution } from '../value-objects/automatic-contribution/AutomaticContribution';
+import { AutomaticContributionAlreadyConfiguredError } from '../errors/AutomaticContributionAlreadyConfiguredError';
 
 const validName = 'Minha Meta';
 const validTotal = 1000;
@@ -99,6 +103,51 @@ describe('Goal', () => {
       const result = goal.delete();
       expect(result.hasError).toBe(true);
       expect(result.errors[0]).toBeInstanceOf(GoalAlreadyDeletedError);
+    });
+  });
+
+  describe('configureAutomaticContribution', () => {
+    const makeContribution = () => {
+      const freq = ContributionFrequency.create({
+        type: FrequencyType.MONTHLY,
+        executionDay: 5,
+        interval: 1,
+        startDate: new Date(Date.now() + 86400000),
+      });
+      return AutomaticContribution.create({
+        amount: 100,
+        frequency: freq,
+        sourceAccountId: EntityId.create().value!.id,
+        startDate: new Date(Date.now() + 86400000),
+        isActive: true,
+      });
+    };
+
+    it('deve configurar aporte se meta ativa', () => {
+      const goal = Goal.create(makeDTO()).data!;
+      const contrib = makeContribution();
+      const result = goal.configureAutomaticContribution(contrib);
+      expect(result.hasError).toBe(false);
+      expect(goal.automaticContribution).toBeDefined();
+    });
+
+    it('deve falhar se meta ja configurada', () => {
+      const goal = Goal.create(makeDTO()).data!;
+      const contrib = makeContribution();
+      goal.configureAutomaticContribution(contrib);
+      const result = goal.configureAutomaticContribution(contrib);
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(
+        AutomaticContributionAlreadyConfiguredError,
+      );
+    });
+
+    it('deve falhar se meta deletada', () => {
+      const goal = Goal.create(makeDTO()).data!;
+      goal.delete();
+      const contrib = makeContribution();
+      const result = goal.configureAutomaticContribution(contrib);
+      expect(result.hasError).toBe(true);
     });
   });
 });

--- a/src/domain/aggregates/goal/goal-entity/Goal.ts
+++ b/src/domain/aggregates/goal/goal-entity/Goal.ts
@@ -14,6 +14,9 @@ import { GoalUpdatedEvent } from '../events/GoalUpdatedEvent';
 import { GoalDeletedEvent } from '../events/GoalDeletedEvent';
 import { GoalAmountAddedEvent } from '../events/GoalAmountAddedEvent';
 import { GoalAchievedEvent } from '../events/GoalAchievedEvent';
+import { AutomaticContribution } from '../value-objects/automatic-contribution/AutomaticContribution';
+import { AutomaticContributionConfiguredEvent } from '../events/AutomaticContributionConfiguredEvent';
+import { AutomaticContributionAlreadyConfiguredError } from '../errors/AutomaticContributionAlreadyConfiguredError';
 
 export interface CreateGoalDTO {
   name: string;
@@ -58,6 +61,7 @@ export class Goal extends AggregateRoot implements IEntity {
     private _deadline: Date | undefined,
     private readonly _budgetId: EntityId,
     private _accumulatedAmount: MoneyVo,
+    private _automaticContribution?: AutomaticContribution,
     existingId?: EntityId,
   ) {
     super();
@@ -84,6 +88,9 @@ export class Goal extends AggregateRoot implements IEntity {
   }
   get budgetId(): string {
     return this._budgetId.value?.id ?? '';
+  }
+  get automaticContribution(): AutomaticContribution | undefined {
+    return this._automaticContribution;
   }
   get createdAt(): Date {
     return this._createdAt;
@@ -192,6 +199,38 @@ export class Goal extends AggregateRoot implements IEntity {
     return Either.success();
   }
 
+  configureAutomaticContribution(
+    contribution: AutomaticContribution,
+  ): Either<DomainError, void> {
+    if (this._isDeleted)
+      return Either.error<DomainError, void>(new GoalAlreadyDeletedError());
+    if (this.isAchieved())
+      return Either.error<DomainError, void>(new GoalAlreadyAchievedError());
+
+    if (this._automaticContribution)
+      return Either.error(
+        new AutomaticContributionAlreadyConfiguredError(),
+      );
+
+    if (contribution.hasError)
+      return Either.errors(contribution.errors);
+
+    this._automaticContribution = contribution;
+    this._updatedAt = new Date();
+
+    this.addEvent(
+      new AutomaticContributionConfiguredEvent(
+        this.id,
+        contribution.value!.amount,
+        contribution.value!.frequency.value!.type,
+        contribution.value!.frequency.value!.executionDay,
+        contribution.value!.frequency.value!.nextExecutionDate,
+      ),
+    );
+
+    return Either.success();
+  }
+
   delete(): Either<DomainError, void> {
     if (this._isDeleted)
       return Either.error<DomainError, void>(new GoalAlreadyDeletedError());
@@ -261,6 +300,7 @@ export class Goal extends AggregateRoot implements IEntity {
       data.deadline,
       budgetIdVo,
       accumulatedAmountVo,
+      undefined,
     );
 
     goal.addEvent(
@@ -305,6 +345,7 @@ export class Goal extends AggregateRoot implements IEntity {
       data.deadline,
       budgetIdVo,
       accumulatedAmountVo,
+      undefined,
       idVo,
     );
 

--- a/src/domain/aggregates/goal/value-objects/automatic-contribution/AutomaticContribution.spec.ts
+++ b/src/domain/aggregates/goal/value-objects/automatic-contribution/AutomaticContribution.spec.ts
@@ -1,0 +1,54 @@
+import { ContributionFrequency } from '../contribution-frequency/ContributionFrequency';
+import { FrequencyType } from '../../enums/FrequencyType';
+import { AutomaticContribution } from './AutomaticContribution';
+import { InvalidContributionAmountError } from '../../errors/InvalidContributionAmountError';
+import { InvalidStartDateError } from '../../errors/InvalidStartDateError';
+
+const makeFrequency = () =>
+  ContributionFrequency.create({
+    type: FrequencyType.MONTHLY,
+    executionDay: 15,
+    interval: 1,
+    startDate: new Date(Date.now() + 86400000),
+  });
+
+describe('AutomaticContribution', () => {
+  it('deve criar valor válido', () => {
+    const freq = makeFrequency();
+    const result = AutomaticContribution.create({
+      amount: 1000,
+      frequency: freq,
+      sourceAccountId: '550e8400-e29b-41d4-a716-446655440001',
+      startDate: new Date(Date.now() + 86400000),
+      isActive: true,
+    });
+    expect(result.hasError).toBe(false);
+    expect(result.value?.amount).toBe(1000);
+  });
+
+  it('deve retornar erro se valor for zero ou negativo', () => {
+    const freq = makeFrequency();
+    const result = AutomaticContribution.create({
+      amount: 0,
+      frequency: freq,
+      sourceAccountId: '550e8400-e29b-41d4-a716-446655440001',
+      startDate: new Date(Date.now() + 86400000),
+      isActive: true,
+    });
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(InvalidContributionAmountError);
+  });
+
+  it('deve retornar erro se startDate estiver no passado', () => {
+    const freq = makeFrequency();
+    const result = AutomaticContribution.create({
+      amount: 100,
+      frequency: freq,
+      sourceAccountId: '550e8400-e29b-41d4-a716-446655440001',
+      startDate: new Date(Date.now() - 86400000),
+      isActive: true,
+    });
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(InvalidStartDateError);
+  });
+});

--- a/src/domain/aggregates/goal/value-objects/automatic-contribution/AutomaticContribution.ts
+++ b/src/domain/aggregates/goal/value-objects/automatic-contribution/AutomaticContribution.ts
@@ -1,0 +1,92 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { EntityId } from '../../../../shared/value-objects/entity-id/EntityId';
+import { MoneyVo } from '../../../../shared/value-objects/money-vo/MoneyVo';
+import { InvalidContributionAmountError } from '../../errors/InvalidContributionAmountError';
+import { InvalidStartDateError } from '../../errors/InvalidStartDateError';
+import { ContributionFrequency } from '../contribution-frequency/ContributionFrequency';
+
+export type AutomaticContributionValue = {
+  amount: number;
+  frequency: ContributionFrequency;
+  sourceAccountId: string;
+  startDate: Date;
+  endDate?: Date;
+  isActive: boolean;
+};
+
+export type AutomaticContributionProps = {
+  amount: number;
+  frequency: ContributionFrequency;
+  sourceAccountId: string;
+  startDate: Date;
+  endDate?: Date;
+  isActive: boolean;
+};
+
+export class AutomaticContribution implements IValueObject<AutomaticContributionValue> {
+  private either = new Either<DomainError, AutomaticContributionValue>();
+
+  private constructor(private props: AutomaticContributionProps) {
+    this.validate();
+  }
+
+  get value(): AutomaticContributionValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return (
+      vo instanceof AutomaticContribution &&
+      !!vo.value &&
+      !!this.value &&
+      vo.value.amount === this.value.amount &&
+      vo.value.frequency.equals(this.props.frequency) &&
+      vo.value.sourceAccountId === this.value.sourceAccountId
+    );
+  }
+
+  static create(props: AutomaticContributionProps): AutomaticContribution {
+    return new AutomaticContribution(props);
+  }
+
+  private validate() {
+    const amountVo = MoneyVo.create(this.props.amount);
+    if (amountVo.hasError || (amountVo.value?.cents ?? 0) <= 0) {
+      this.either.addError(new InvalidContributionAmountError());
+    }
+
+    if (this.props.frequency.hasError) {
+      this.either.addManyErrors(this.props.frequency.errors);
+    }
+
+    const sourceId = EntityId.fromString(this.props.sourceAccountId);
+    if (sourceId.hasError) this.either.addManyErrors(sourceId.errors);
+
+    const now = new Date();
+    if (this.props.startDate.getTime() < now.getTime()) {
+      this.either.addError(new InvalidStartDateError());
+    }
+
+    if (!this.either.hasError) {
+      this.either.setData({
+        amount: amountVo.value!.cents,
+        frequency: this.props.frequency,
+        sourceAccountId: sourceId.value!.id,
+        startDate: this.props.startDate,
+        endDate: this.props.endDate,
+        isActive: this.props.isActive,
+      });
+    }
+  }
+}

--- a/src/domain/aggregates/goal/value-objects/contribution-frequency/ContributionFrequency.spec.ts
+++ b/src/domain/aggregates/goal/value-objects/contribution-frequency/ContributionFrequency.spec.ts
@@ -1,0 +1,27 @@
+import { ContributionFrequency } from './ContributionFrequency';
+import { FrequencyType } from '../../enums/FrequencyType';
+import { InvalidFrequencyConfigurationError } from '../../errors/InvalidFrequencyConfigurationError';
+
+describe('ContributionFrequency', () => {
+  it('deve criar frequência mensal válida', () => {
+    const freq = ContributionFrequency.create({
+      type: FrequencyType.MONTHLY,
+      executionDay: 10,
+      interval: 1,
+      startDate: new Date('2025-01-01'),
+    });
+    expect(freq.hasError).toBe(false);
+    expect(freq.value?.type).toBe(FrequencyType.MONTHLY);
+  });
+
+  it('deve falhar se dia inválido para semanal', () => {
+    const freq = ContributionFrequency.create({
+      type: FrequencyType.WEEKLY,
+      executionDay: 10,
+      interval: 1,
+      startDate: new Date('2025-01-01'),
+    });
+    expect(freq.hasError).toBe(true);
+    expect(freq.errors[0]).toBeInstanceOf(InvalidFrequencyConfigurationError);
+  });
+});

--- a/src/domain/aggregates/goal/value-objects/contribution-frequency/ContributionFrequency.ts
+++ b/src/domain/aggregates/goal/value-objects/contribution-frequency/ContributionFrequency.ts
@@ -1,0 +1,105 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidFrequencyConfigurationError } from '../../errors/InvalidFrequencyConfigurationError';
+import { FrequencyType } from '../../enums/FrequencyType';
+
+export type ContributionFrequencyValue = {
+  type: FrequencyType;
+  executionDay: number;
+  interval: number;
+  nextExecutionDate: Date;
+};
+
+export type ContributionFrequencyProps = {
+  type: FrequencyType;
+  executionDay: number;
+  interval: number;
+  startDate: Date;
+};
+
+export class ContributionFrequency implements IValueObject<ContributionFrequencyValue> {
+  private either = new Either<DomainError, ContributionFrequencyValue>();
+
+  private constructor(private props: ContributionFrequencyProps) {
+    this.validate();
+  }
+
+  get value(): ContributionFrequencyValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return (
+      vo instanceof ContributionFrequency &&
+      vo.value?.type === this.value?.type &&
+      vo.value?.executionDay === this.value?.executionDay &&
+      vo.value?.interval === this.value?.interval
+    );
+  }
+
+  static create(props: ContributionFrequencyProps): ContributionFrequency {
+    return new ContributionFrequency(props);
+  }
+
+  private validate() {
+    if (!Object.values(FrequencyType).includes(this.props.type)) {
+      this.either.addError(new InvalidFrequencyConfigurationError());
+      return;
+    }
+
+    if (this.props.interval <= 0) {
+      this.either.addError(new InvalidFrequencyConfigurationError());
+    }
+
+    if (this.props.type === FrequencyType.WEEKLY) {
+      if (this.props.executionDay < 1 || this.props.executionDay > 7) {
+        this.either.addError(new InvalidFrequencyConfigurationError());
+      }
+    } else {
+      if (this.props.executionDay < 1 || this.props.executionDay > 31) {
+        this.either.addError(new InvalidFrequencyConfigurationError());
+      }
+    }
+
+    const nextDate = this.calculateNextDate();
+    if (!this.either.hasError) {
+      this.either.setData({
+        type: this.props.type,
+        executionDay: this.props.executionDay,
+        interval: this.props.interval,
+        nextExecutionDate: nextDate,
+      });
+    }
+  }
+
+  private calculateNextDate(): Date {
+    const start = new Date(this.props.startDate);
+    if (this.props.type === FrequencyType.WEEKLY) {
+      const desired = this.props.executionDay % 7; // 1-7 => 1-7 with 7->0
+      const day = start.getDay() === 0 ? 7 : start.getDay();
+      const diff = (desired - day + 7) % 7;
+      start.setDate(start.getDate() + diff);
+    } else if (this.props.type === FrequencyType.MONTHLY) {
+      start.setDate(this.props.executionDay);
+      if (start < this.props.startDate) {
+        start.setMonth(start.getMonth() + this.props.interval);
+      }
+    } else if (this.props.type === FrequencyType.YEARLY) {
+      start.setDate(this.props.executionDay);
+      if (start < this.props.startDate) {
+        start.setFullYear(start.getFullYear() + this.props.interval);
+      }
+    }
+    return start;
+  }
+}


### PR DESCRIPTION
## Summary
- add FrequencyType enum
- implement value objects for contribution frequency and automatic contribution
- create event AutomaticContributionConfiguredEvent
- extend Goal entity with configureAutomaticContribution
- add repository contract and use case for configuring automatic contributions
- include related errors and stubs
- add comprehensive unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d391c696483239116c1eb55dfc97c