### PR TITLE
Implement UC018 mark transaction late

### DIFF
--- a/src/application/contracts/repositories/transaction/IMarkTransactionLateRepository.ts
+++ b/src/application/contracts/repositories/transaction/IMarkTransactionLateRepository.ts
@@ -1,0 +1,9 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { Either } from '@either';
+
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+
+export interface IMarkTransactionLateRepository {
+  findOverdue(date: Date): Promise<Either<RepositoryError, Transaction[]>>;
+  save(transaction: Transaction): Promise<Either<RepositoryError, void>>;
+}

--- a/src/application/services/transaction/TransactionSchedulerService.spec.ts
+++ b/src/application/services/transaction/TransactionSchedulerService.spec.ts
@@ -1,0 +1,61 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionStatusEnum } from '@domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+
+import { EventPublisherStub } from '../../shared/tests/stubs/EventPublisherStub';
+import { MarkTransactionLateRepositoryStub } from '../../shared/tests/stubs/MarkTransactionLateRepositoryStub';
+import { TransactionSchedulerService } from './TransactionSchedulerService';
+
+describe('TransactionSchedulerService', () => {
+  let repository: MarkTransactionLateRepositoryStub;
+  let eventPublisher: EventPublisherStub;
+  let service: TransactionSchedulerService;
+
+  beforeEach(() => {
+    repository = new MarkTransactionLateRepositoryStub();
+    eventPublisher = new EventPublisherStub();
+    service = new TransactionSchedulerService(repository, eventPublisher);
+  });
+
+  it('should mark overdue transactions as late', async () => {
+    const tx = Transaction.create({
+      description: 'late',
+      amount: 100,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: new Date(Date.now() - 86400000),
+      categoryId: EntityId.create().value!.id,
+      budgetId: EntityId.create().value!.id,
+      accountId: EntityId.create().value!.id,
+      status: TransactionStatusEnum.SCHEDULED,
+    }).data!;
+    repository.overdueTransactions = [tx];
+
+    const result = await service.processLateTransactions();
+
+    expect(result.processed).toHaveLength(1);
+    expect(tx.status).toBe(TransactionStatusEnum.LATE);
+    expect(repository.saveCalls).toHaveLength(1);
+    expect(eventPublisher.publishManyCalls).toHaveLength(1);
+  });
+
+  it('should skip transactions when marking fails', async () => {
+    const tx = Transaction.create({
+      description: 'future',
+      amount: 100,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: new Date(Date.now() + 86400000),
+      categoryId: EntityId.create().value!.id,
+      budgetId: EntityId.create().value!.id,
+      accountId: EntityId.create().value!.id,
+      status: TransactionStatusEnum.SCHEDULED,
+    }).data!;
+    repository.overdueTransactions = [tx];
+
+    const result = await service.processLateTransactions();
+
+    expect(result.processed).toHaveLength(0);
+    expect(repository.saveCalls).toHaveLength(0);
+    expect(eventPublisher.publishManyCalls).toHaveLength(0);
+  });
+});

--- a/src/application/services/transaction/TransactionSchedulerService.ts
+++ b/src/application/services/transaction/TransactionSchedulerService.ts
@@ -1,0 +1,38 @@
+import { IEventPublisher } from '../../contracts/events/IEventPublisher';
+import { IMarkTransactionLateRepository } from '../../contracts/repositories/transaction/IMarkTransactionLateRepository';
+
+export class TransactionSchedulerService {
+  constructor(
+    private readonly repository: IMarkTransactionLateRepository,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async processLateTransactions(date: Date = new Date()) {
+    const overdueResult = await this.repository.findOverdue(date);
+    if (overdueResult.hasError || !overdueResult.data) {
+      return { processed: [] as string[] };
+    }
+
+    const processed: string[] = [];
+    for (const tx of overdueResult.data) {
+      const markResult = tx.markAsLate();
+      if (markResult.hasError) continue;
+
+      const saveResult = await this.repository.save(tx);
+      if (saveResult.hasError) continue;
+
+      const events = tx.getEvents();
+      if (events.length > 0) {
+        try {
+          await this.eventPublisher.publishMany(events);
+          tx.clearEvents();
+        } catch (error) {
+          console.error('Failed to publish events:', error);
+        }
+      }
+      processed.push(tx.id);
+    }
+
+    return { processed };
+  }
+}

--- a/src/application/shared/tests/stubs/MarkTransactionLateRepositoryStub.ts
+++ b/src/application/shared/tests/stubs/MarkTransactionLateRepositoryStub.ts
@@ -1,0 +1,28 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { Either } from '@either';
+
+import { IMarkTransactionLateRepository } from '../../../contracts/repositories/transaction/IMarkTransactionLateRepository';
+import { RepositoryError } from '../../errors/RepositoryError';
+
+export class MarkTransactionLateRepositoryStub implements IMarkTransactionLateRepository {
+  public overdueTransactions: Transaction[] = [];
+  public shouldFail = false;
+  public findCalls = 0;
+  public saveCalls: Transaction[] = [];
+
+  async findOverdue(date: Date): Promise<Either<RepositoryError, Transaction[]>> {
+    this.findCalls++;
+    if (this.shouldFail) {
+      return Either.error(new RepositoryError('Repository failure'));
+    }
+    return Either.success(this.overdueTransactions);
+  }
+
+  async save(transaction: Transaction): Promise<Either<RepositoryError, void>> {
+    this.saveCalls.push(transaction);
+    if (this.shouldFail) {
+      return Either.error(new RepositoryError('Repository failure'));
+    }
+    return Either.success();
+  }
+}

--- a/src/application/use-cases/transaction/mark-transaction-late/MarkTransactionLateDto.ts
+++ b/src/application/use-cases/transaction/mark-transaction-late/MarkTransactionLateDto.ts
@@ -1,0 +1,4 @@
+export interface MarkTransactionLateDto {
+  transactionId: string;
+  lateDate?: Date;
+}

--- a/src/application/use-cases/transaction/mark-transaction-late/MarkTransactionLateUseCase.spec.ts
+++ b/src/application/use-cases/transaction/mark-transaction-late/MarkTransactionLateUseCase.spec.ts
@@ -1,0 +1,95 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionStatusEnum } from '@domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+
+import { TransactionNotFoundError } from '../../../shared/errors/TransactionNotFoundError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { GetTransactionRepositoryStub } from '../../../shared/tests/stubs/GetTransactionRepositoryStub';
+import { MarkTransactionLateRepositoryStub } from '../../../shared/tests/stubs/MarkTransactionLateRepositoryStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { MarkTransactionLateDto } from './MarkTransactionLateDto';
+import { MarkTransactionLateUseCase } from './MarkTransactionLateUseCase';
+
+describe('MarkTransactionLateUseCase', () => {
+  let useCase: MarkTransactionLateUseCase;
+  let getTransactionRepositoryStub: GetTransactionRepositoryStub;
+  let saveTransactionRepositoryStub: MarkTransactionLateRepositoryStub;
+  let eventPublisherStub: EventPublisherStub;
+  let transaction: Transaction;
+
+  beforeEach(() => {
+    getTransactionRepositoryStub = new GetTransactionRepositoryStub();
+    saveTransactionRepositoryStub = new MarkTransactionLateRepositoryStub();
+    eventPublisherStub = new EventPublisherStub();
+
+    const txResult = Transaction.create({
+      description: 'test',
+      amount: 100,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: new Date(Date.now() - 86400000),
+      categoryId: EntityId.create().value!.id,
+      budgetId: EntityId.create().value!.id,
+      accountId: EntityId.create().value!.id,
+      status: TransactionStatusEnum.SCHEDULED,
+    });
+    transaction = txResult.data!;
+    transaction.clearEvents();
+    getTransactionRepositoryStub.mockTransaction = transaction;
+
+    useCase = new MarkTransactionLateUseCase(
+      getTransactionRepositoryStub,
+      saveTransactionRepositoryStub,
+      eventPublisherStub,
+    );
+  });
+
+  it('should mark transaction as late', async () => {
+    const dto: MarkTransactionLateDto = { transactionId: transaction.id };
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(false);
+    expect(saveTransactionRepositoryStub.shouldFail).toBeFalsy();
+    expect(transaction.status).toBe(TransactionStatusEnum.LATE);
+    expect(eventPublisherStub.publishManyCalls).toHaveLength(1);
+  });
+
+  it('should return error when transaction not found', async () => {
+    getTransactionRepositoryStub.shouldReturnNull = true;
+    const dto: MarkTransactionLateDto = { transactionId: 'non-existent' };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(TransactionNotFoundError);
+  });
+
+  it('should return domain error when mark fails', async () => {
+    transaction = Transaction.create({
+      description: 'test',
+      amount: 100,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: new Date(Date.now() + 86400000),
+      categoryId: EntityId.create().value!.id,
+      budgetId: EntityId.create().value!.id,
+      accountId: EntityId.create().value!.id,
+      status: TransactionStatusEnum.SCHEDULED,
+    }).data!;
+    getTransactionRepositoryStub.mockTransaction = transaction;
+    const dto: MarkTransactionLateDto = { transactionId: transaction.id };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+  });
+
+  it('should return error when save fails', async () => {
+    saveTransactionRepositoryStub.shouldFail = true;
+    const dto: MarkTransactionLateDto = { transactionId: transaction.id };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(TransactionPersistenceFailedError);
+  });
+});

--- a/src/application/use-cases/transaction/mark-transaction-late/MarkTransactionLateUseCase.ts
+++ b/src/application/use-cases/transaction/mark-transaction-late/MarkTransactionLateUseCase.ts
@@ -1,0 +1,56 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IGetTransactionRepository } from '../../../contracts/repositories/transaction/IGetTransactionRepository';
+import { IMarkTransactionLateRepository } from '../../../contracts/repositories/transaction/IMarkTransactionLateRepository';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { TransactionNotFoundError } from '../../../shared/errors/TransactionNotFoundError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+import { MarkTransactionLateDto } from './MarkTransactionLateDto';
+
+export class MarkTransactionLateUseCase implements IUseCase<MarkTransactionLateDto> {
+  constructor(
+    private readonly getTransactionRepository: IGetTransactionRepository,
+    private readonly markTransactionLateRepository: IMarkTransactionLateRepository,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(dto: MarkTransactionLateDto) {
+    const txResult = await this.getTransactionRepository.execute(dto.transactionId);
+    if (txResult.hasError || !txResult.data) {
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>([
+        new TransactionNotFoundError(),
+      ]);
+    }
+
+    const transaction = txResult.data;
+    const markResult = transaction.markAsLate();
+    if (markResult.hasError) {
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>(markResult.errors);
+    }
+
+    const saveResult = await this.markTransactionLateRepository.save(transaction);
+    if (saveResult.hasError) {
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>([
+        new TransactionPersistenceFailedError(),
+      ]);
+    }
+
+    const events = transaction.getEvents();
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        transaction.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success<ApplicationError | DomainError, UseCaseResponse>({
+      id: transaction.id,
+    });
+  }
+}

--- a/src/domain/aggregates/transaction/events/TransactionMarkedAsLateEvent.ts
+++ b/src/domain/aggregates/transaction/events/TransactionMarkedAsLateEvent.ts
@@ -1,0 +1,7 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+
+export class TransactionMarkedAsLateEvent extends DomainEvent {
+  constructor(aggregateId: string) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus.ts
+++ b/src/domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus.ts
@@ -9,6 +9,7 @@ export enum TransactionStatusEnum {
   COMPLETED = 'COMPLETED',
   OVERDUE = 'OVERDUE',
   CANCELLED = 'CANCELLED',
+  LATE = 'LATE',
 }
 
 export type TransactionStatusValue = {


### PR DESCRIPTION
## Summary
- add `LATE` status for transactions
- fire `TransactionMarkedAsLateEvent` and implement markAsLate()
- create use case for marking late transactions
- add transaction scheduler service
- provide stub repository and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d39149c288323a2bc6392bdfd5413