### PR TITLE
Implement UC016 Register Past Transaction

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -534,8 +534,9 @@ Este documento descreve todos os casos de uso (features) da aplicação OrçaSon
 
 ---
 
-### ❌ UC016: Registrar Transação Passada
-**Status**: Não Implementado
+### ✅ UC016: Registrar Transação Passada
+**Status**: Implementado
+**Arquivo**: [`RegisterPastTransactionUseCase.ts`](../src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.ts)
 
 **Descrição**: Permite registrar uma transação que ocorreu no passado.
 

--- a/src/application/contracts/unit-of-works/IRegisterPastTransactionUnitOfWork.ts
+++ b/src/application/contracts/unit-of-works/IRegisterPastTransactionUnitOfWork.ts
@@ -1,0 +1,11 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+export interface IRegisterPastTransactionUnitOfWork {
+  execute(params: {
+    account: Account;
+    transaction: Transaction;
+  }): Promise<Either<DomainError, void>>;
+}

--- a/src/application/shared/tests/stubs/IRegisterPastTransactionUnitOfWorkStub.ts
+++ b/src/application/shared/tests/stubs/IRegisterPastTransactionUnitOfWorkStub.ts
@@ -1,0 +1,20 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IRegisterPastTransactionUnitOfWork } from '@application/contracts/unit-of-works/IRegisterPastTransactionUnitOfWork';
+
+export class IRegisterPastTransactionUnitOfWorkStub
+  implements IRegisterPastTransactionUnitOfWork
+{
+  public executeCalls: Array<{ account: Account; transaction: Transaction }> = [];
+
+  async execute(params: {
+    account: Account;
+    transaction: Transaction;
+  }): Promise<Either<DomainError, void>> {
+    this.executeCalls.push(params);
+    return Either.success(undefined);
+  }
+}

--- a/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionDto.ts
+++ b/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionDto.ts
@@ -1,0 +1,12 @@
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+
+export interface RegisterPastTransactionDto {
+  userId: string;
+  budgetId: string;
+  accountId: string;
+  categoryId: string;
+  amount: number;
+  description: string;
+  transactionDate: Date;
+  type: TransactionTypeEnum;
+}

--- a/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.spec.ts
+++ b/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.spec.ts
@@ -1,0 +1,225 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { AccountTypeEnum } from '@domain/aggregates/account/value-objects/account-type/AccountType';
+import { Category } from '@domain/aggregates/category/category-entity/Category';
+import { CategoryTypeEnum } from '@domain/aggregates/category/value-objects/category-type/CategoryType';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { Either } from '@either';
+
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { CategoryNotFoundError } from '../../../shared/errors/CategoryNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionCreationFailedError } from '../../../shared/errors/TransactionCreationFailedError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { IRegisterPastTransactionUnitOfWorkStub } from '../../../shared/tests/stubs/IRegisterPastTransactionUnitOfWorkStub';
+
+import { RegisterPastTransactionDto } from './RegisterPastTransactionDto';
+import { RegisterPastTransactionUseCase } from './RegisterPastTransactionUseCase';
+
+describe('RegisterPastTransactionUseCase', () => {
+  let useCase: RegisterPastTransactionUseCase;
+  let getAccountRepositoryStub: GetAccountRepositoryStub;
+  let getCategoryRepository: { execute: jest.Mock };
+  let unitOfWorkStub: IRegisterPastTransactionUnitOfWorkStub;
+  let authServiceStub: BudgetAuthorizationServiceStub;
+  let eventPublisherStub: EventPublisherStub;
+
+  let account: Account;
+  let category: Category;
+  const userId = EntityId.create().value!.id;
+  const budgetId = EntityId.create().value!.id;
+
+  beforeEach(() => {
+    getAccountRepositoryStub = new GetAccountRepositoryStub();
+    getCategoryRepository = { execute: jest.fn() };
+    unitOfWorkStub = new IRegisterPastTransactionUnitOfWorkStub();
+    authServiceStub = new BudgetAuthorizationServiceStub();
+    eventPublisherStub = new EventPublisherStub();
+
+    useCase = new RegisterPastTransactionUseCase(
+      getAccountRepositoryStub,
+      getCategoryRepository as any,
+      unitOfWorkStub,
+      authServiceStub,
+      eventPublisherStub,
+    );
+
+    account = Account.create({
+      name: 'Conta',
+      type: AccountTypeEnum.CHECKING_ACCOUNT,
+      budgetId,
+      initialBalance: 1000,
+    }).data!;
+
+    category = Category.create({
+      name: 'Cat',
+      type: CategoryTypeEnum.EXPENSE,
+      budgetId,
+    }).data!;
+
+    getAccountRepositoryStub.mockAccount = account;
+    getCategoryRepository.execute.mockResolvedValue(Either.success(category));
+  });
+
+  afterEach(() => {
+    getAccountRepositoryStub.executeCalls = [];
+    unitOfWorkStub.executeCalls = [];
+    getCategoryRepository.execute.mockReset();
+  });
+
+  it('should register past transaction successfully', async () => {
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - 5);
+    const dto: RegisterPastTransactionDto = {
+      userId,
+      budgetId,
+      accountId: account.id,
+      categoryId: category.id,
+      amount: 500,
+      description: 'Compra',
+      transactionDate: pastDate,
+      type: TransactionTypeEnum.EXPENSE,
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(false);
+    expect(unitOfWorkStub.executeCalls.length).toBe(1);
+    expect(account.balance).toBe(500);
+    expect(result.data!.id).toBeDefined();
+  });
+
+  it('should fail when date is in the future', async () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 1);
+    const dto: RegisterPastTransactionDto = {
+      userId,
+      budgetId,
+      accountId: account.id,
+      categoryId: category.id,
+      amount: 500,
+      description: 'Compra',
+      transactionDate: future,
+      type: TransactionTypeEnum.EXPENSE,
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(TransactionCreationFailedError);
+  });
+
+  it('should fail when date is too old', async () => {
+    const old = new Date();
+    old.setFullYear(old.getFullYear() - 2);
+    const dto: RegisterPastTransactionDto = {
+      userId,
+      budgetId,
+      accountId: account.id,
+      categoryId: category.id,
+      amount: 500,
+      description: 'Compra',
+      transactionDate: old,
+      type: TransactionTypeEnum.EXPENSE,
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(TransactionCreationFailedError);
+  });
+
+  it('should fail when account not found', async () => {
+    getAccountRepositoryStub.shouldReturnNull = true;
+
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - 2);
+    const dto: RegisterPastTransactionDto = {
+      userId,
+      budgetId,
+      accountId: account.id,
+      categoryId: category.id,
+      amount: 100,
+      description: 'Compra',
+      transactionDate: pastDate,
+      type: TransactionTypeEnum.EXPENSE,
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new AccountNotFoundError());
+  });
+
+  it('should fail when category not found', async () => {
+    getCategoryRepository.execute.mockResolvedValue(Either.success(null));
+
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - 2);
+    const dto: RegisterPastTransactionDto = {
+      userId,
+      budgetId,
+      accountId: account.id,
+      categoryId: category.id,
+      amount: 100,
+      description: 'Compra',
+      transactionDate: pastDate,
+      type: TransactionTypeEnum.EXPENSE,
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new CategoryNotFoundError());
+  });
+
+  it('should fail when unauthorized', async () => {
+    authServiceStub.mockHasAccess = false;
+
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - 2);
+    const dto: RegisterPastTransactionDto = {
+      userId,
+      budgetId,
+      accountId: account.id,
+      categoryId: category.id,
+      amount: 100,
+      description: 'Compra',
+      transactionDate: pastDate,
+      type: TransactionTypeEnum.EXPENSE,
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new InsufficientPermissionsError());
+  });
+
+  it('should return persistence error when unit of work fails', async () => {
+    jest
+      .spyOn(unitOfWorkStub, 'execute')
+      .mockResolvedValueOnce(Either.error(new Error('fail') as any));
+
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - 2);
+    const dto: RegisterPastTransactionDto = {
+      userId,
+      budgetId,
+      accountId: account.id,
+      categoryId: category.id,
+      amount: 100,
+      description: 'Compra',
+      transactionDate: pastDate,
+      type: TransactionTypeEnum.EXPENSE,
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new TransactionPersistenceFailedError());
+  });
+});

--- a/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.ts
+++ b/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.ts
@@ -1,0 +1,115 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IGetAccountRepository } from '../../../contracts/repositories/account/IGetAccountRepository';
+import { IGetCategoryByIdRepository } from '../../../contracts/repositories/category/IGetCategoryByIdRepository';
+import { IRegisterPastTransactionUnitOfWork } from '../../../contracts/unit-of-works/IRegisterPastTransactionUnitOfWork';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { CategoryNotFoundError } from '../../../shared/errors/CategoryNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionCreationFailedError } from '../../../shared/errors/TransactionCreationFailedError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+import { RegisterPastTransactionDto } from './RegisterPastTransactionDto';
+
+export class RegisterPastTransactionUseCase
+  implements IUseCase<RegisterPastTransactionDto>
+{
+  constructor(
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly getCategoryRepository: IGetCategoryByIdRepository,
+    private readonly unitOfWork: IRegisterPastTransactionUnitOfWork,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(
+    dto: RegisterPastTransactionDto,
+  ): Promise<Either<DomainError | ApplicationError, UseCaseResponse>> {
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      dto.budgetId,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors(authResult.errors);
+    }
+
+    if (!authResult.data) {
+      return Either.error(new InsufficientPermissionsError());
+    }
+
+    const accountResult = await this.getAccountRepository.execute(dto.accountId);
+
+    if (accountResult.hasError) {
+      return Either.error(new AccountRepositoryError());
+    }
+
+    const account = accountResult.data;
+    if (!account || account.budgetId !== dto.budgetId) {
+      return Either.error(new AccountNotFoundError());
+    }
+
+    const categoryResult = await this.getCategoryRepository.execute(dto.categoryId);
+    if (categoryResult.hasError) {
+      return Either.errors(categoryResult.errors);
+    }
+
+    const category = categoryResult.data;
+    if (!category || category.budgetId !== dto.budgetId) {
+      return Either.error(new CategoryNotFoundError());
+    }
+
+    const transactionResult = Transaction.createPastTransaction({
+      description: dto.description,
+      amount: dto.amount,
+      type: dto.type,
+      accountId: dto.accountId,
+      categoryId: dto.categoryId,
+      budgetId: dto.budgetId,
+      transactionDate: dto.transactionDate,
+    });
+
+    if (transactionResult.hasError) {
+      const reason = transactionResult.errors.map((e) => e.message).join('; ');
+      return Either.error(new TransactionCreationFailedError(reason));
+    }
+
+    const transaction = transactionResult.data!;
+
+    const operation =
+      transaction.type === TransactionTypeEnum.EXPENSE
+        ? account.subtractAmount(transaction.amount)
+        : account.addAmount(transaction.amount);
+    if (operation.hasError) {
+      return Either.errors(operation.errors);
+    }
+
+    const uowResult = await this.unitOfWork.execute({
+      account,
+      transaction,
+    });
+
+    if (uowResult.hasError) {
+      return Either.error(new TransactionPersistenceFailedError());
+    }
+
+    const events = transaction.getEvents();
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        transaction.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success({ id: transaction.id });
+  }
+}

--- a/src/domain/aggregates/transaction/errors/InvalidTransactionDateError.ts
+++ b/src/domain/aggregates/transaction/errors/InvalidTransactionDateError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidTransactionDateError extends DomainError {
+  constructor(message = 'Invalid transaction date') {
+    super(message);
+    this.name = 'InvalidTransactionDateError';
+    this.fieldName = 'transactionDate';
+  }
+}


### PR DESCRIPTION
## Summary
- implement InvalidTransactionDateError
- add Transaction.createPastTransaction factory and unit tests
- create RegisterPastTransaction use case with DTO, unit of work interface and tests
- document implemented UC016 in features list

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_688d35a52cac8323a7d2e2a9f54a2dfa