### PR TITLE
Implement UC031 Mark Credit Card Bill as Paid

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -14,8 +14,8 @@ Este documento descreve todos os casos de uso (features) da aplicação OrçaSon
 ## 📊 **Resumo Geral**
 
 - **Total de Use Cases**: 60
-- **Implementados**: 25 (42%)
-- **Não Implementados**: 35 (58%)
+- **Implementados**: 26 (43%)
+- **Não Implementados**: 34 (57%)
 
 ---
 
@@ -1064,8 +1064,9 @@ Este documento descreve todos os casos de uso (features) da aplicação OrçaSon
 
 ---
 
-### ❌ UC031: Marcar Fatura como Paga
-**Status**: Não Implementado
+### ✅ UC031: Marcar Fatura como Paga
+**Status**: Implementado
+**Arquivo**: [`MarkCreditCardBillAsPaidUseCase.ts`](../src/application/use-cases/credit-card-bill/mark-bill-as-paid/MarkCreditCardBillAsPaidUseCase.ts)
 
 **Descrição**: Marca uma fatura do cartão como paga e registra o pagamento.
 
@@ -1497,8 +1498,8 @@ Este documento descreve todos os casos de uso (features) da aplicação OrçaSon
 
 ## 📈 **Estatísticas Finais**
 
-- **✅ Implementados**: 25 use cases (42%)
-- **❌ Não Implementados**: 35 use cases (58%)
+- **✅ Implementados**: 26 use cases (43%)
+- **❌ Não Implementados**: 34 use cases (57%)
 
 ### **Priorização Sugerida para Próximas Implementações**:
 

--- a/src/application/contracts/repositories/credit-card-bill/IMarkCreditCardBillAsPaidRepository.ts
+++ b/src/application/contracts/repositories/credit-card-bill/IMarkCreditCardBillAsPaidRepository.ts
@@ -1,0 +1,14 @@
+import { Either } from '@either';
+
+import { CreditCardBill } from '@domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill';
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { RepositoryError } from '../../shared/errors/RepositoryError';
+
+export interface IMarkCreditCardBillAsPaidRepository {
+  execute(params: {
+    creditCardBill: CreditCardBill;
+    account: Account;
+    transaction: Transaction;
+  }): Promise<Either<RepositoryError, void>>;
+}

--- a/src/application/shared/errors/CreditCardBillPaymentFailedError.ts
+++ b/src/application/shared/errors/CreditCardBillPaymentFailedError.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from './ApplicationError';
+
+export class CreditCardBillPaymentFailedError extends ApplicationError {
+  constructor(message: string) {
+    super(`Failed to pay credit card bill: ${message}`);
+  }
+}

--- a/src/application/shared/tests/stubs/MarkCreditCardBillAsPaidRepositoryStub.ts
+++ b/src/application/shared/tests/stubs/MarkCreditCardBillAsPaidRepositoryStub.ts
@@ -1,0 +1,30 @@
+import { CreditCardBill } from '@domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill';
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { Either } from '@either';
+
+import { IMarkCreditCardBillAsPaidRepository } from '../../../contracts/repositories/credit-card-bill/IMarkCreditCardBillAsPaidRepository';
+import { RepositoryError } from '../../errors/RepositoryError';
+
+export class MarkCreditCardBillAsPaidRepositoryStub
+  implements IMarkCreditCardBillAsPaidRepository
+{
+  public shouldFail = false;
+  public executeCalls: Array<{
+    creditCardBill: CreditCardBill;
+    account: Account;
+    transaction: Transaction;
+  }> = [];
+
+  async execute(params: {
+    creditCardBill: CreditCardBill;
+    account: Account;
+    transaction: Transaction;
+  }): Promise<Either<RepositoryError, void>> {
+    this.executeCalls.push(params);
+    if (this.shouldFail) {
+      return Either.error(new RepositoryError('Repository failure'));
+    }
+    return Either.success();
+  }
+}

--- a/src/application/use-cases/credit-card-bill/mark-bill-as-paid/MarkCreditCardBillAsPaidDto.ts
+++ b/src/application/use-cases/credit-card-bill/mark-bill-as-paid/MarkCreditCardBillAsPaidDto.ts
@@ -1,0 +1,9 @@
+export interface MarkCreditCardBillAsPaidDto {
+  userId: string;
+  budgetId: string;
+  creditCardBillId: string;
+  paymentAmount: number;
+  paymentDate: Date;
+  sourceAccountId: string;
+  description?: string;
+}

--- a/src/application/use-cases/credit-card-bill/mark-bill-as-paid/MarkCreditCardBillAsPaidUseCase.spec.ts
+++ b/src/application/use-cases/credit-card-bill/mark-bill-as-paid/MarkCreditCardBillAsPaidUseCase.spec.ts
@@ -1,0 +1,129 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { AccountTypeEnum } from '@domain/aggregates/account/value-objects/account-type/AccountType';
+import { CreditCardBill } from '@domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill';
+import { CreditCardBillAlreadyPaidError } from '@domain/aggregates/credit-card-bill/errors/CreditCardBillAlreadyPaidError';
+import { BillStatusEnum } from '@domain/aggregates/credit-card-bill/value-objects/bill-status/BillStatus';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { Either } from '@either';
+
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { CreditCardBillNotFoundError } from '../../../shared/errors/CreditCardBillNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { MarkCreditCardBillAsPaidRepositoryStub } from '../../../shared/tests/stubs/MarkCreditCardBillAsPaidRepositoryStub';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { GetCreditCardBillRepositoryStub } from '../../../shared/tests/stubs/GetCreditCardBillRepositoryStub';
+import { MarkCreditCardBillAsPaidDto } from './MarkCreditCardBillAsPaidDto';
+import { MarkCreditCardBillAsPaidUseCase } from './MarkCreditCardBillAsPaidUseCase';
+
+const PAYMENT_CATEGORY_ID = EntityId.create().value!.id;
+
+const makeCreditCardBill = (): CreditCardBill => {
+  const data = {
+    creditCardId: EntityId.create().value!.id,
+    closingDate: new Date('2024-01-01'),
+    dueDate: new Date('2024-01-25'),
+    amount: 50000,
+  };
+  const result = CreditCardBill.create(data);
+  if (result.hasError) throw new Error('fail');
+  return result.data!;
+};
+
+const makeAccount = (budgetId: string): Account => {
+  const result = Account.create({
+    name: 'Conta',
+    type: AccountTypeEnum.CHECKING_ACCOUNT,
+    budgetId,
+    initialBalance: 100000,
+  });
+  if (result.hasError) throw new Error('fail');
+  return result.data!;
+};
+
+describe('MarkCreditCardBillAsPaidUseCase', () => {
+  let useCase: MarkCreditCardBillAsPaidUseCase;
+  let getBillRepo: GetCreditCardBillRepositoryStub;
+  let getAccountRepo: GetAccountRepositoryStub;
+  let markRepo: MarkCreditCardBillAsPaidRepositoryStub;
+  let authService: BudgetAuthorizationServiceStub;
+  let eventPublisher: EventPublisherStub;
+  let account: Account;
+  let bill: CreditCardBill;
+  const userId = EntityId.create().value!.id;
+  const budgetId = EntityId.create().value!.id;
+
+  beforeEach(() => {
+    getBillRepo = new GetCreditCardBillRepositoryStub();
+    getAccountRepo = new GetAccountRepositoryStub();
+    markRepo = new MarkCreditCardBillAsPaidRepositoryStub();
+    authService = new BudgetAuthorizationServiceStub();
+    eventPublisher = new EventPublisherStub();
+    useCase = new MarkCreditCardBillAsPaidUseCase(
+      getBillRepo,
+      getAccountRepo,
+      markRepo,
+      authService,
+      eventPublisher,
+      PAYMENT_CATEGORY_ID,
+    );
+
+    bill = makeCreditCardBill();
+    account = makeAccount(budgetId);
+    getBillRepo.setCreditCardBill(bill);
+    getAccountRepo.mockAccount = account;
+  });
+
+  const makeDto = (): MarkCreditCardBillAsPaidDto => ({
+    userId,
+    budgetId,
+    creditCardBillId: bill.id,
+    paymentAmount: 50000,
+    paymentDate: new Date('2024-01-20'),
+    sourceAccountId: account.id,
+  });
+
+  it('should pay bill successfully', async () => {
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(false);
+    expect(markRepo.executeCalls.length).toBe(1);
+    expect(eventPublisher.publishManyCalls.length).toBe(1);
+  });
+
+  it('should return error when bill not found', async () => {
+    getBillRepo.setCreditCardBill(null);
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new CreditCardBillNotFoundError());
+  });
+
+  it('should return error when bill already paid', async () => {
+    bill.markAsPaid(50000, new Date('2024-01-10'));
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(CreditCardBillAlreadyPaidError);
+  });
+
+  it('should return error when account not found', async () => {
+    getAccountRepo.mockAccount = null;
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new AccountNotFoundError());
+  });
+
+  it('should return error when user lacks permission', async () => {
+    authService.mockHasAccess = false;
+    const dto = makeDto();
+    const result = await useCase.execute(dto);
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new InsufficientPermissionsError());
+  });
+});

--- a/src/application/use-cases/credit-card-bill/mark-bill-as-paid/MarkCreditCardBillAsPaidUseCase.ts
+++ b/src/application/use-cases/credit-card-bill/mark-bill-as-paid/MarkCreditCardBillAsPaidUseCase.ts
@@ -1,0 +1,137 @@
+import { Either } from '@either';
+import { IUseCase, UseCaseResponse } from '@application/shared/IUseCase';
+import { ApplicationError } from '@application/shared/errors/ApplicationError';
+import { CreditCardBillNotFoundError } from '@application/shared/errors/CreditCardBillNotFoundError';
+import { AccountNotFoundError } from '@application/shared/errors/AccountNotFoundError';
+import { InsufficientPermissionsError } from '@application/shared/errors/InsufficientPermissionsError';
+import { RepositoryError } from '@application/shared/errors/RepositoryError';
+import { CreditCardBillPaymentFailedError } from '@application/shared/errors/CreditCardBillPaymentFailedError';
+import { CreditCardBillAlreadyPaidError } from '@domain/aggregates/credit-card-bill/errors/CreditCardBillAlreadyPaidError';
+import { InsufficientBalanceError } from '@domain/aggregates/account/errors/InsufficientBalanceError';
+import { IGetCreditCardBillRepository } from '@application/contracts/repositories/credit-card-bill/IGetCreditCardBillRepository';
+import { IGetAccountRepository } from '@application/contracts/repositories/account/IGetAccountRepository';
+import { IMarkCreditCardBillAsPaidRepository } from '@application/contracts/repositories/credit-card-bill/IMarkCreditCardBillAsPaidRepository';
+import { IBudgetAuthorizationService } from '@application/services/authorization/IBudgetAuthorizationService';
+import { IEventPublisher } from '@application/contracts/events/IEventPublisher';
+import { DomainError } from '@domain/shared/DomainError';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { BillStatusEnum } from '@domain/aggregates/credit-card-bill/value-objects/bill-status/BillStatus';
+import { MarkCreditCardBillAsPaidDto } from './MarkCreditCardBillAsPaidDto';
+
+export class MarkCreditCardBillAsPaidUseCase
+  implements IUseCase<MarkCreditCardBillAsPaidDto>
+{
+  constructor(
+    private readonly getCreditCardBillRepository: IGetCreditCardBillRepository,
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly markCreditCardBillAsPaidRepository: IMarkCreditCardBillAsPaidRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+    private readonly paymentCategoryId: string,
+  ) {}
+
+  async execute(
+    dto: MarkCreditCardBillAsPaidDto,
+  ): Promise<Either<DomainError | ApplicationError, UseCaseResponse>> {
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      dto.budgetId,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors(authResult.errors);
+    }
+
+    if (!authResult.data) {
+      return Either.errors([new InsufficientPermissionsError()]);
+    }
+
+    const billResult = await this.getCreditCardBillRepository.execute(
+      dto.creditCardBillId,
+    );
+
+    if (billResult.hasError) {
+      const error = billResult.errors[0] as RepositoryError;
+      return Either.error(new CreditCardBillPaymentFailedError(error.message));
+    }
+
+    const bill = billResult.data;
+    if (!bill) {
+      return Either.error(new CreditCardBillNotFoundError());
+    }
+
+    if (bill.status !== BillStatusEnum.OPEN) {
+      return Either.error(new CreditCardBillAlreadyPaidError());
+    }
+
+    const accountResult = await this.getAccountRepository.execute(
+      dto.sourceAccountId,
+    );
+
+    if (accountResult.hasError) {
+      const error = accountResult.errors[0] as RepositoryError;
+      return Either.error(new CreditCardBillPaymentFailedError(error.message));
+    }
+
+    const account = accountResult.data;
+    if (!account) {
+      return Either.error(new AccountNotFoundError());
+    }
+
+    if (!account.canSubtract(dto.paymentAmount)) {
+      return Either.errors([new InsufficientBalanceError()]);
+    }
+
+    const markResult = bill.markAsPaid(dto.paymentAmount, dto.paymentDate);
+    if (markResult.hasError) {
+      return Either.errors(markResult.errors);
+    }
+
+    const subtractResult = account.subtractAmount(dto.paymentAmount);
+    if (subtractResult.hasError) {
+      return Either.errors(subtractResult.errors);
+    }
+
+    const transactionResult = Transaction.create({
+      description:
+        dto.description || 'Pagamento fatura cartão',
+      amount: dto.paymentAmount,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: dto.paymentDate,
+      categoryId: this.paymentCategoryId,
+      budgetId: dto.budgetId,
+      accountId: dto.sourceAccountId,
+    });
+
+    if (transactionResult.hasError) {
+      return Either.errors(transactionResult.errors);
+    }
+
+    const transaction = transactionResult.data!;
+
+    const repoResult = await this.markCreditCardBillAsPaidRepository.execute({
+      creditCardBill: bill,
+      account,
+      transaction,
+    });
+
+    if (repoResult.hasError) {
+      const error = repoResult.errors[0] as RepositoryError;
+      return Either.error(new CreditCardBillPaymentFailedError(error.message));
+    }
+
+    const events = [...bill.getEvents(), ...transaction.getEvents()];
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        bill.clearEvents();
+        transaction.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish domain events:', error);
+      }
+    }
+
+    return Either.success({ id: bill.id });
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/errors/InvalidPaymentAmountError.ts
+++ b/src/domain/aggregates/credit-card-bill/errors/InvalidPaymentAmountError.ts
@@ -1,0 +1,8 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidPaymentAmountError extends DomainError {
+  constructor() {
+    super('The payment amount provided is invalid');
+    this.name = 'InvalidPaymentAmountError';
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/errors/InvalidPaymentDateError.ts
+++ b/src/domain/aggregates/credit-card-bill/errors/InvalidPaymentDateError.ts
@@ -1,0 +1,8 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidPaymentDateError extends DomainError {
+  constructor() {
+    super('The payment date provided is invalid');
+    this.name = 'InvalidPaymentDateError';
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/value-objects/payment-amount/PaymentAmount.spec.ts
+++ b/src/domain/aggregates/credit-card-bill/value-objects/payment-amount/PaymentAmount.spec.ts
@@ -1,0 +1,26 @@
+import { InvalidPaymentAmountError } from '../../errors/InvalidPaymentAmountError';
+import { PaymentAmount } from './PaymentAmount';
+
+describe('PaymentAmount', () => {
+  it('deve criar um valor de pagamento válido', () => {
+    const vo = PaymentAmount.create(100.5);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.amount).toBe(100.5);
+  });
+
+  it('deve retornar erro se valor for zero ou negativo', () => {
+    let vo = PaymentAmount.create(0);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidPaymentAmountError());
+
+    vo = PaymentAmount.create(-10);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidPaymentAmountError());
+  });
+
+  it('deve retornar erro se tiver mais de duas casas decimais', () => {
+    const vo = PaymentAmount.create(10.123);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidPaymentAmountError());
+  });
+});

--- a/src/domain/aggregates/credit-card-bill/value-objects/payment-amount/PaymentAmount.ts
+++ b/src/domain/aggregates/credit-card-bill/value-objects/payment-amount/PaymentAmount.ts
@@ -1,0 +1,54 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidPaymentAmountError } from '../../errors/InvalidPaymentAmountError';
+
+export type PaymentAmountValue = {
+  amount: number;
+};
+
+export class PaymentAmount implements IValueObject<PaymentAmountValue> {
+  private either = new Either<DomainError, PaymentAmountValue>();
+
+  private constructor(private _amount: number) {
+    this.validate();
+  }
+
+  get value(): PaymentAmountValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return vo instanceof PaymentAmount && vo.value?.amount === this.value?.amount;
+  }
+
+  static create(amount: number): PaymentAmount {
+    return new PaymentAmount(amount);
+  }
+
+  private validate() {
+    if (typeof this._amount !== 'number' || isNaN(this._amount) || !isFinite(this._amount)) {
+      this.either.addError(new InvalidPaymentAmountError());
+      return;
+    }
+
+    if (this._amount <= 0) {
+      this.either.addError(new InvalidPaymentAmountError());
+    }
+
+    if (Math.round(this._amount * 100) !== this._amount * 100) {
+      this.either.addError(new InvalidPaymentAmountError());
+    }
+
+    this.either.setData({ amount: this._amount });
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/value-objects/payment-date/PaymentDate.spec.ts
+++ b/src/domain/aggregates/credit-card-bill/value-objects/payment-date/PaymentDate.spec.ts
@@ -1,0 +1,27 @@
+import { InvalidPaymentDateError } from '../../errors/InvalidPaymentDateError';
+import { PaymentDate } from './PaymentDate';
+
+describe('PaymentDate', () => {
+  const closingDate = new Date('2024-01-01');
+
+  it('deve criar uma data válida', () => {
+    const vo = PaymentDate.create(new Date('2024-01-10'), closingDate);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.date).toEqual(new Date('2024-01-10'));
+  });
+
+  it('deve retornar erro se data for futura', () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 1);
+    const vo = PaymentDate.create(future, closingDate);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidPaymentDateError());
+  });
+
+  it('deve retornar erro se data for antes do período', () => {
+    const past = new Date('2023-12-31');
+    const vo = PaymentDate.create(past, closingDate);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidPaymentDateError());
+  });
+});

--- a/src/domain/aggregates/credit-card-bill/value-objects/payment-date/PaymentDate.ts
+++ b/src/domain/aggregates/credit-card-bill/value-objects/payment-date/PaymentDate.ts
@@ -1,0 +1,55 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidPaymentDateError } from '../../errors/InvalidPaymentDateError';
+
+export type PaymentDateValue = {
+  date: Date;
+};
+
+export class PaymentDate implements IValueObject<PaymentDateValue> {
+  private either = new Either<DomainError, PaymentDateValue>();
+
+  private constructor(private _date: Date, private readonly _minDate: Date) {
+    this.validate();
+  }
+
+  get value(): PaymentDateValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return vo instanceof PaymentDate && vo.value?.date.getTime() === this.value?.date.getTime();
+  }
+
+  static create(date: Date, minDate: Date): PaymentDate {
+    return new PaymentDate(date, minDate);
+  }
+
+  private validate() {
+    if (!(this._date instanceof Date) || isNaN(this._date.getTime())) {
+      this.either.addError(new InvalidPaymentDateError());
+      return;
+    }
+
+    const now = new Date();
+    if (this._date.getTime() > now.getTime()) {
+      this.either.addError(new InvalidPaymentDateError());
+    }
+
+    if (this._date.getTime() < this._minDate.getTime()) {
+      this.either.addError(new InvalidPaymentDateError());
+    }
+
+    this.either.setData({ date: this._date });
+  }
+}


### PR DESCRIPTION
## Summary
- add PaymentAmount and PaymentDate value objects
- add application contract and error for paying credit card bill
- implement markAsPaid logic on CreditCardBill
- implement MarkCreditCardBillAsPaid use case and tests
- add repository stub and update features documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d358f1464832397c4c19177570f80