### PR TITLE
Implement UC012 Reconciliar Saldo

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -14,8 +14,8 @@ Este documento descreve todos os casos de uso (features) da aplicação OrçaSon
 ## 📊 **Resumo Geral**
 
 - **Total de Use Cases**: 60
-- **Implementados**: 25 (42%)
-- **Não Implementados**: 35 (58%)
+- **Implementados**: 26 (43%)
+- **Não Implementados**: 34 (57%)
 
 ---
 
@@ -385,8 +385,9 @@ Este documento descreve todos os casos de uso (features) da aplicação OrçaSon
 
 ---
 
-### ❌ UC012: Reconciliar Saldo
-**Status**: Não Implementado
+### ✅ UC012: Reconciliar Saldo
+**Status**: Implementado
+**Arquivo**: [`ReconcileAccountUseCase.ts`](../src/application/use-cases/account/reconcile-account/ReconcileAccountUseCase.ts)
 
 **Descrição**: Permite ajustar o saldo da conta baseado no extrato bancário real.
 
@@ -408,9 +409,9 @@ Este documento descreve todos os casos de uso (features) da aplicação OrçaSon
 8. Sistema exibe confirmação
 
 **Critérios de Aceitação**:
-- ❌ Diferença deve ser justificada
-- ❌ Transação de ajuste é claramente identificada
-- ❌ Histórico de reconciliações é mantido
+- ✅ Diferença deve ser justificada
+- ✅ Transação de ajuste é claramente identificada
+- ✅ Histórico de reconciliações é mantido
 
 **Domain Events**:
 - `AccountReconciledEvent`
@@ -1497,8 +1498,8 @@ Este documento descreve todos os casos de uso (features) da aplicação OrçaSon
 
 ## 📈 **Estatísticas Finais**
 
-- **✅ Implementados**: 25 use cases (42%)
-- **❌ Não Implementados**: 35 use cases (58%)
+- **✅ Implementados**: 26 use cases (43%)
+- **❌ Não Implementados**: 34 use cases (57%)
 
 ### **Priorização Sugerida para Próximas Implementações**:
 

--- a/src/application/contracts/repositories/account/IReconcileAccountRepository.ts
+++ b/src/application/contracts/repositories/account/IReconcileAccountRepository.ts
@@ -1,0 +1,12 @@
+import { Either } from '@either';
+
+import { Account } from '../../../../domain/aggregates/account/account-entity/Account';
+import { Transaction } from '../../../../domain/aggregates/transaction/transaction-entity/Transaction';
+import { RepositoryError } from '../../../shared/errors/RepositoryError';
+
+export interface IReconcileAccountRepository {
+  execute(params: {
+    account: Account;
+    transaction: Transaction;
+  }): Promise<Either<RepositoryError, void>>;
+}

--- a/src/application/shared/tests/stubs/ReconcileAccountRepositoryStub.ts
+++ b/src/application/shared/tests/stubs/ReconcileAccountRepositoryStub.ts
@@ -1,0 +1,22 @@
+import { Either } from '@either';
+
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { IReconcileAccountRepository } from '../../../contracts/repositories/account/IReconcileAccountRepository';
+import { RepositoryError } from '../../errors/RepositoryError';
+
+export class ReconcileAccountRepositoryStub implements IReconcileAccountRepository {
+  public shouldFail = false;
+  public executeCalls: Array<{ account: Account; transaction: Transaction }> = [];
+
+  async execute(params: {
+    account: Account;
+    transaction: Transaction;
+  }): Promise<Either<RepositoryError, void>> {
+    this.executeCalls.push(params);
+    if (this.shouldFail) {
+      return Either.error(new RepositoryError('Repository failure'));
+    }
+    return Either.success();
+  }
+}

--- a/src/application/use-cases/account/reconcile-account/ReconcileAccountDto.ts
+++ b/src/application/use-cases/account/reconcile-account/ReconcileAccountDto.ts
@@ -1,0 +1,7 @@
+export interface ReconcileAccountDto {
+  userId: string;
+  budgetId: string;
+  accountId: string;
+  realBalance: number;
+  justification: string;
+}

--- a/src/application/use-cases/account/reconcile-account/ReconcileAccountUseCase.spec.ts
+++ b/src/application/use-cases/account/reconcile-account/ReconcileAccountUseCase.spec.ts
@@ -1,0 +1,127 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { AccountTypeEnum } from '@domain/aggregates/account/value-objects/account-type/AccountType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { ReconcileAccountRepositoryStub } from '../../../shared/tests/stubs/ReconcileAccountRepositoryStub';
+import { ReconcileAccountDto } from './ReconcileAccountDto';
+import { ReconcileAccountUseCase } from './ReconcileAccountUseCase';
+
+describe('ReconcileAccountUseCase', () => {
+  let useCase: ReconcileAccountUseCase;
+  let getAccountRepositoryStub: GetAccountRepositoryStub;
+  let reconcileAccountRepositoryStub: ReconcileAccountRepositoryStub;
+  let budgetAuthorizationServiceStub: BudgetAuthorizationServiceStub;
+  let eventPublisherStub: EventPublisherStub;
+  let account: Account;
+  const userId = EntityId.create().value!.id;
+  const adjustmentCategoryId = EntityId.create().value!.id;
+
+  beforeEach(() => {
+    getAccountRepositoryStub = new GetAccountRepositoryStub();
+    reconcileAccountRepositoryStub = new ReconcileAccountRepositoryStub();
+    budgetAuthorizationServiceStub = new BudgetAuthorizationServiceStub();
+    eventPublisherStub = new EventPublisherStub();
+    useCase = new ReconcileAccountUseCase(
+      getAccountRepositoryStub,
+      reconcileAccountRepositoryStub,
+      budgetAuthorizationServiceStub,
+      eventPublisherStub,
+      adjustmentCategoryId,
+    );
+
+    const result = Account.create({
+      name: 'Conta',
+      type: AccountTypeEnum.CHECKING_ACCOUNT,
+      budgetId: EntityId.create().value!.id,
+      initialBalance: 1000,
+    });
+    account = result.data!;
+    getAccountRepositoryStub.mockAccount = account;
+    budgetAuthorizationServiceStub.mockHasAccess = true;
+  });
+
+  it('should reconcile with positive difference', async () => {
+    const dto: ReconcileAccountDto = {
+      userId,
+      budgetId: account.budgetId!,
+      accountId: account.id,
+      realBalance: 1500,
+      justification: 'Deposito esquecido',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasData).toBe(true);
+    expect(account.balance).toBe(1500);
+    expect(reconcileAccountRepositoryStub.executeCalls).toHaveLength(1);
+  });
+
+  it('should reconcile with negative difference', async () => {
+    const dto: ReconcileAccountDto = {
+      userId,
+      budgetId: account.budgetId!,
+      accountId: account.id,
+      realBalance: 800,
+      justification: 'Tarifa bancária',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasData).toBe(true);
+    expect(account.balance).toBe(800);
+  });
+
+  it('should return error when account not found', async () => {
+    getAccountRepositoryStub.shouldReturnNull = true;
+    const dto: ReconcileAccountDto = {
+      userId,
+      budgetId: account.budgetId!,
+      accountId: EntityId.create().value!.id,
+      realBalance: 1100,
+      justification: 'Justificativa valida',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new AccountNotFoundError());
+  });
+
+  it('should return permission error', async () => {
+    budgetAuthorizationServiceStub.mockHasAccess = false;
+    const dto: ReconcileAccountDto = {
+      userId,
+      budgetId: account.budgetId!,
+      accountId: account.id,
+      realBalance: 1200,
+      justification: 'Justificativa valida',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new InsufficientPermissionsError());
+  });
+
+  it('should return repository error on persistence fail', async () => {
+    reconcileAccountRepositoryStub.shouldFail = true;
+    const dto: ReconcileAccountDto = {
+      userId,
+      budgetId: account.budgetId!,
+      accountId: account.id,
+      realBalance: 1400,
+      justification: 'Justificativa valida',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new TransactionPersistenceFailedError());
+  });
+});

--- a/src/application/use-cases/account/reconcile-account/ReconcileAccountUseCase.ts
+++ b/src/application/use-cases/account/reconcile-account/ReconcileAccountUseCase.ts
@@ -1,0 +1,124 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { ReconciliationAmount } from '@domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount';
+import { ReconciliationJustification } from '@domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionStatusEnum } from '@domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IGetAccountRepository } from '../../../contracts/repositories/account/IGetAccountRepository';
+import { IReconcileAccountRepository } from '../../../contracts/repositories/account/IReconcileAccountRepository';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionCreationFailedError } from '../../../shared/errors/TransactionCreationFailedError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { ReconcileAccountDto } from './ReconcileAccountDto';
+import { IUseCase } from '../../../shared/IUseCase';
+
+export class ReconcileAccountUseCase implements IUseCase<ReconcileAccountDto> {
+  constructor(
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly reconcileAccountRepository: IReconcileAccountRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+    private readonly adjustmentCategoryId: string,
+  ) {}
+
+  async execute(
+    dto: ReconcileAccountDto,
+  ): Promise<Either<DomainError | ApplicationError, { id: string }>> {
+    const accountResult = await this.getAccountRepository.execute(dto.accountId);
+
+    if (accountResult.hasError) {
+      return Either.errors([new AccountRepositoryError()]);
+    }
+
+    if (!accountResult.data) {
+      return Either.errors([new AccountNotFoundError()]);
+    }
+
+    const account = accountResult.data as Account;
+
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      account.budgetId!,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors(authResult.errors);
+    }
+
+    if (!authResult.data) {
+      return Either.errors([new InsufficientPermissionsError()]);
+    }
+
+    const diff = dto.realBalance - (account.balance ?? 0);
+    const diffVo = ReconciliationAmount.create(diff);
+    const justificationVo = ReconciliationJustification.create(dto.justification);
+
+    const either = new Either<DomainError | ApplicationError, { id: string }>();
+    if (diffVo.hasError) either.addManyErrors(diffVo.errors);
+    if (justificationVo.hasError) either.addManyErrors(justificationVo.errors);
+    if (either.hasError) return either;
+
+    const reconcileResult = account.reconcile(
+      dto.realBalance,
+      justificationVo.value!.justification,
+    );
+
+    if (reconcileResult.hasError) {
+      return Either.errors(reconcileResult.errors);
+    }
+
+    const transactionResult = Transaction.create({
+      description: 'Ajuste de Reconciliação',
+      amount: Math.abs(diffVo.value!.amount),
+      type:
+        diffVo.value!.amount > 0
+          ? TransactionTypeEnum.INCOME
+          : TransactionTypeEnum.EXPENSE,
+      accountId: account.id,
+      budgetId: account.budgetId!,
+      categoryId: this.adjustmentCategoryId,
+      transactionDate: new Date(),
+      status: TransactionStatusEnum.COMPLETED,
+    });
+
+    if (transactionResult.hasError) {
+      const msg = transactionResult.errors.map((e) => e.message).join('; ');
+      return Either.errors([new TransactionCreationFailedError(msg)]);
+    }
+
+    const transaction = transactionResult.data!;
+
+    const persistResult = await this.reconcileAccountRepository.execute({
+      account,
+      transaction,
+    });
+
+    if (persistResult.hasError) {
+      return Either.errors([new TransactionPersistenceFailedError()]);
+    }
+
+    const events = [
+      ...account.getEvents(),
+      ...transaction.getEvents(),
+    ];
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        account.clearEvents();
+        transaction.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success({ id: account.id });
+  }
+}

--- a/src/domain/aggregates/account/account-entity/Account.spec.ts
+++ b/src/domain/aggregates/account/account-entity/Account.spec.ts
@@ -497,4 +497,48 @@ describe('Account', () => {
       });
     });
   });
+
+  describe('reconcile', () => {
+    const budgetId = EntityId.create().value!.id;
+
+    it('should reconcile with positive difference', () => {
+      const acc = Account.create({
+        name: 'Conta Teste',
+        type: AccountTypeEnum.CHECKING_ACCOUNT,
+        budgetId,
+        initialBalance: 1000,
+      }).data!;
+
+      const result = acc.reconcile(1500, 'Ajuste de deposito');
+      expect(result.hasError).toBe(false);
+      expect(result.data).toBe(500);
+      expect(acc.balance).toBe(1500);
+    });
+
+    it('should reconcile with negative difference', () => {
+      const acc = Account.create({
+        name: 'Conta',
+        type: AccountTypeEnum.CHECKING_ACCOUNT,
+        budgetId,
+        initialBalance: 1000,
+      }).data!;
+
+      const result = acc.reconcile(800, 'Tarifa bancaria');
+      expect(result.hasError).toBe(false);
+      expect(result.data).toBe(-200);
+      expect(acc.balance).toBe(800);
+    });
+
+    it('should return error when difference below threshold', () => {
+      const acc = Account.create({
+        name: 'Conta',
+        type: AccountTypeEnum.CHECKING_ACCOUNT,
+        budgetId,
+        initialBalance: 1000,
+      }).data!;
+
+      const result = acc.reconcile(1000, 'Sem diferenca');
+      expect(result.hasError).toBe(true);
+    });
+  });
 });

--- a/src/domain/aggregates/account/account-entity/Account.ts
+++ b/src/domain/aggregates/account/account-entity/Account.ts
@@ -10,12 +10,16 @@ import { InsufficientBalanceError } from '../errors/InsufficientBalanceError';
 import { InvalidAccountDataError } from '../errors/InvalidAccountDataError';
 import { AccountDeletedEvent } from '../events/AccountDeletedEvent';
 import { AccountUpdatedEvent } from '../events/AccountUpdatedEvent';
+import { AccountReconciledEvent } from '../events/AccountReconciledEvent';
 import {
   AccountType,
   AccountTypeEnum,
 } from '../value-objects/account-type/AccountType';
 import { EntityName } from './../../../shared/value-objects/entity-name/EntityName';
 import { InvalidTransferAmountError } from './errors/InvalidTransferAmountError';
+import { ReconciliationAmount } from '../value-objects/reconciliation-amount/ReconciliationAmount';
+import { ReconciliationJustification } from '../value-objects/reconciliation-justification/ReconciliationJustification';
+import { ReconciliationNotNecessaryError } from '../errors/ReconciliationNotNecessaryError';
 
 export interface CreateAccountDTO {
   name: string;
@@ -336,5 +340,47 @@ export class Account extends AggregateRoot implements IEntity {
     }
 
     return Either.success(undefined);
+  }
+
+  reconcile(
+    realBalance: number,
+    justification: string,
+  ): Either<DomainError, number> {
+    const justificationVo =
+      ReconciliationJustification.create(justification);
+    const balanceVo = BalanceVo.create(realBalance);
+
+    const either = new Either<DomainError, number>();
+    if (justificationVo.hasError) either.addManyErrors(justificationVo.errors);
+    if (balanceVo.hasError) either.addManyErrors(balanceVo.errors);
+
+    const current = this._balance.value?.cents ?? 0;
+    const diff = parseFloat((realBalance - current).toFixed(2));
+    const diffVo = ReconciliationAmount.create(diff);
+    if (diffVo.hasError) either.addManyErrors(diffVo.errors);
+
+    if (either.hasError) return either;
+
+    if (Math.abs(diff) < 1) {
+      return Either.errors<DomainError, number>([
+        new ReconciliationNotNecessaryError(),
+      ]);
+    }
+
+    this._balance = balanceVo;
+    this._updatedAt = new Date();
+
+    this.addEvent(
+      new AccountReconciledEvent(
+        this.id,
+        this.budgetId!,
+        current,
+        realBalance,
+        diff,
+        justificationVo.value!.justification,
+      ),
+    );
+
+    return Either.success(diff);
   }
 }

--- a/src/domain/aggregates/account/errors/InvalidReconciliationAmountError.ts
+++ b/src/domain/aggregates/account/errors/InvalidReconciliationAmountError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidReconciliationAmountError extends DomainError {
+  constructor(value: unknown) {
+    super(`Invalid reconciliation amount: ${value}`);
+    this.name = 'InvalidReconciliationAmountError';
+    this.fieldName = 'amount';
+  }
+}

--- a/src/domain/aggregates/account/errors/InvalidReconciliationJustificationError.ts
+++ b/src/domain/aggregates/account/errors/InvalidReconciliationJustificationError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidReconciliationJustificationError extends DomainError {
+  constructor() {
+    super('Invalid reconciliation justification');
+    this.name = 'InvalidReconciliationJustificationError';
+    this.fieldName = 'justification';
+  }
+}

--- a/src/domain/aggregates/account/errors/ReconciliationNotNecessaryError.ts
+++ b/src/domain/aggregates/account/errors/ReconciliationNotNecessaryError.ts
@@ -1,0 +1,8 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class ReconciliationNotNecessaryError extends DomainError {
+  constructor() {
+    super('Reconciliation not necessary');
+    this.name = 'ReconciliationNotNecessaryError';
+  }
+}

--- a/src/domain/aggregates/account/events/AccountReconciledEvent.spec.ts
+++ b/src/domain/aggregates/account/events/AccountReconciledEvent.spec.ts
@@ -1,0 +1,32 @@
+import { AccountReconciledEvent } from './AccountReconciledEvent';
+
+describe('AccountReconciledEvent', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should create event with all properties', () => {
+    const event = new AccountReconciledEvent(
+      'acc',
+      'budget',
+      100,
+      150,
+      50,
+      'ajuste',
+    );
+
+    expect(event.aggregateId).toBe('acc');
+    expect(event.budgetId).toBe('budget');
+    expect(event.previousBalance).toBe(100);
+    expect(event.newBalance).toBe(150);
+    expect(event.difference).toBe(50);
+    expect(event.justification).toBe('ajuste');
+    expect(event.occurredOn).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+    expect(event.eventVersion).toBe(1);
+  });
+});

--- a/src/domain/aggregates/account/events/AccountReconciledEvent.ts
+++ b/src/domain/aggregates/account/events/AccountReconciledEvent.ts
@@ -1,0 +1,14 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+
+export class AccountReconciledEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly budgetId: string,
+    public readonly previousBalance: number,
+    public readonly newBalance: number,
+    public readonly difference: number,
+    public readonly justification: string,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount.spec.ts
+++ b/src/domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount.spec.ts
@@ -1,0 +1,34 @@
+import { ReconciliationAmount } from './ReconciliationAmount';
+import { InvalidReconciliationAmountError } from '../../errors/InvalidReconciliationAmountError';
+
+describe('ReconciliationAmount', () => {
+  it('should create a valid positive amount', () => {
+    const vo = ReconciliationAmount.create(10.5);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.amount).toBe(10.5);
+  });
+
+  it('should create a valid negative amount', () => {
+    const vo = ReconciliationAmount.create(-5);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.amount).toBe(-5);
+  });
+
+  it('should return error for zero amount', () => {
+    const vo = ReconciliationAmount.create(0);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidReconciliationAmountError(0));
+  });
+
+  it('should return error for more than two decimals', () => {
+    const vo = ReconciliationAmount.create(1.234);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidReconciliationAmountError(1.234));
+  });
+
+  it('should return error for NaN', () => {
+    const vo = ReconciliationAmount.create(NaN);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidReconciliationAmountError(NaN));
+  });
+});

--- a/src/domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount.ts
+++ b/src/domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount.ts
@@ -1,0 +1,54 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidReconciliationAmountError } from '../../errors/InvalidReconciliationAmountError';
+
+export type ReconciliationAmountValue = {
+  amount: number;
+};
+
+export class ReconciliationAmount implements IValueObject<ReconciliationAmountValue> {
+  private either = new Either<DomainError, ReconciliationAmountValue>();
+
+  private constructor(private _amount: number) {
+    this.validate();
+  }
+
+  static create(amount: number): ReconciliationAmount {
+    return new ReconciliationAmount(amount);
+  }
+
+  get value(): ReconciliationAmountValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return vo instanceof ReconciliationAmount && vo.value?.amount === this.value?.amount;
+  }
+
+  private validate() {
+    if (typeof this._amount !== 'number' || isNaN(this._amount) || !isFinite(this._amount)) {
+      this.either.addError(new InvalidReconciliationAmountError(this._amount));
+      return;
+    }
+
+    if (this._amount === 0) {
+      this.either.addError(new InvalidReconciliationAmountError(this._amount));
+    }
+
+    if (Math.round(this._amount * 100) !== this._amount * 100) {
+      this.either.addError(new InvalidReconciliationAmountError(this._amount));
+    }
+
+    this.either.setData({ amount: this._amount });
+  }
+}

--- a/src/domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification.spec.ts
+++ b/src/domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification.spec.ts
@@ -1,0 +1,28 @@
+import { ReconciliationJustification } from './ReconciliationJustification';
+import { InvalidReconciliationJustificationError } from '../../errors/InvalidReconciliationJustificationError';
+
+describe('ReconciliationJustification', () => {
+  it('should create valid justification', () => {
+    const vo = ReconciliationJustification.create('Ajuste devido a tarifa bancária');
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.justification).toBe('Ajuste devido a tarifa bancária');
+  });
+
+  it('should trim spaces', () => {
+    const vo = ReconciliationJustification.create('   Just  ');
+    expect(vo.hasError).toBe(true);
+  });
+
+  it('should return error when short', () => {
+    const vo = ReconciliationJustification.create('short');
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidReconciliationJustificationError());
+  });
+
+  it('should return error when too long', () => {
+    const long = 'a'.repeat(501);
+    const vo = ReconciliationJustification.create(long);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidReconciliationJustificationError());
+  });
+});

--- a/src/domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification.ts
+++ b/src/domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification.ts
@@ -1,0 +1,55 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidReconciliationJustificationError } from '../../errors/InvalidReconciliationJustificationError';
+
+export type ReconciliationJustificationValue = {
+  justification: string;
+};
+
+export class ReconciliationJustification implements IValueObject<ReconciliationJustificationValue> {
+  private either = new Either<DomainError, ReconciliationJustificationValue>();
+  private static readonly MIN_LENGTH = 10;
+  private static readonly MAX_LENGTH = 500;
+
+  private constructor(private _justification: string) {
+    this.validate();
+  }
+
+  static create(justification: string): ReconciliationJustification {
+    return new ReconciliationJustification(justification);
+  }
+
+  get value(): ReconciliationJustificationValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return (
+      vo instanceof ReconciliationJustification &&
+      vo.value?.justification === this.value?.justification
+    );
+  }
+
+  private validate() {
+    const trimmed = this._justification?.trim();
+    if (
+      !trimmed ||
+      trimmed.length < ReconciliationJustification.MIN_LENGTH ||
+      trimmed.length > ReconciliationJustification.MAX_LENGTH
+    ) {
+      this.either.addError(new InvalidReconciliationJustificationError());
+    }
+
+    this.either.setData({ justification: trimmed });
+  }
+}


### PR DESCRIPTION
## Summary
- add reconciliation value objects and domain errors
- implement Account.reconcile with AccountReconciledEvent
- create ReconcileAccountUseCase and repository contract
- add repository stub and tests
- document UC012 as implemented

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d357da1f88323b470dfb60206e25e