### PR TITLE
Implement UC019 Cancel Scheduled Transaction

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,5 @@
+# Funcionalidades
+
+| ID    | Descrição                   | Status |
+| ----- | --------------------------- | ------ |
+| UC019 | Cancelar Transação Agendada | ✅     |

--- a/docs/tasks/UC019-cancelar-transacao-agendada.md
+++ b/docs/tasks/UC019-cancelar-transacao-agendada.md
@@ -1,0 +1,12 @@
+# UC019 - Cancelar Transação Agendada
+
+- [x] Criar value object `CancellationReason`
+- [x] Implementar erros `TransactionNotScheduledError`, `TransactionAlreadyExecutedError`, `InvalidCancellationReasonError`
+- [x] Atualizar método `Transaction.cancel()` para aceitar motivo e regras
+- [x] Criar `ScheduledTransactionCancelledEvent`
+- [x] Implementar caso de uso `CancelScheduledTransactionUseCase`
+- [x] Testes unitários para value object
+- [x] Testes unitários para Transaction.cancel
+- [x] Testes do caso de uso cobrindo cenários de erro
+- [x] Cobertura mínima 90%
+- [x] Documentar feature em `docs/features.md`

--- a/src/application/shared/tests/stubs/SaveTransactionRepositoryStub.ts
+++ b/src/application/shared/tests/stubs/SaveTransactionRepositoryStub.ts
@@ -8,11 +8,12 @@ export class SaveTransactionRepositoryStub
   implements ISaveTransactionRepository
 {
   public shouldFail = false;
+  public executeCalls: Transaction[] = [];
 
   async execute(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     transaction: Transaction,
   ): Promise<Either<RepositoryError, void>> {
+    this.executeCalls.push(transaction);
     if (this.shouldFail) {
       return Either.error(new RepositoryError('Repository failure'));
     }

--- a/src/application/use-cases/transaction/cancel-scheduled-transaction/CancelScheduledTransactionDto.ts
+++ b/src/application/use-cases/transaction/cancel-scheduled-transaction/CancelScheduledTransactionDto.ts
@@ -1,0 +1,5 @@
+export interface CancelScheduledTransactionDto {
+  id: string;
+  userId: string;
+  reason: string;
+}

--- a/src/application/use-cases/transaction/cancel-scheduled-transaction/CancelScheduledTransactionUseCase.spec.ts
+++ b/src/application/use-cases/transaction/cancel-scheduled-transaction/CancelScheduledTransactionUseCase.spec.ts
@@ -1,0 +1,128 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionStatusEnum } from '@domain/aggregates/transaction/value-objects/transaction-status/TransactionStatus';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionNotFoundError } from '../../../shared/errors/TransactionNotFoundError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetTransactionRepositoryStub } from '../../../shared/tests/stubs/GetTransactionRepositoryStub';
+import { SaveTransactionRepositoryStub } from '../../../shared/tests/stubs/SaveTransactionRepositoryStub';
+import { CancelScheduledTransactionDto } from './CancelScheduledTransactionDto';
+import { CancelScheduledTransactionUseCase } from './CancelScheduledTransactionUseCase';
+
+describe('CancelScheduledTransactionUseCase', () => {
+  let useCase: CancelScheduledTransactionUseCase;
+  let getTransactionRepositoryStub: GetTransactionRepositoryStub;
+  let saveTransactionRepositoryStub: SaveTransactionRepositoryStub;
+  let budgetAuthorizationServiceStub: BudgetAuthorizationServiceStub;
+  let eventPublisherStub: EventPublisherStub;
+  let mockTransaction: Transaction;
+
+  beforeEach(() => {
+    getTransactionRepositoryStub = new GetTransactionRepositoryStub();
+    saveTransactionRepositoryStub = new SaveTransactionRepositoryStub();
+    budgetAuthorizationServiceStub = new BudgetAuthorizationServiceStub();
+    eventPublisherStub = new EventPublisherStub();
+
+    const transactionResult = Transaction.create({
+      description: 'Test Transaction',
+      amount: 100,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: new Date(Date.now() + 86400000),
+      categoryId: EntityId.create().value!.id,
+      budgetId: EntityId.create().value!.id,
+      accountId: EntityId.create().value!.id,
+      status: TransactionStatusEnum.SCHEDULED,
+    });
+
+    if (transactionResult.hasError) {
+      throw new Error('Failed to create transaction');
+    }
+
+    mockTransaction = transactionResult.data!;
+    mockTransaction.clearEvents();
+    getTransactionRepositoryStub.mockTransaction = mockTransaction;
+    budgetAuthorizationServiceStub.mockHasAccess = true;
+
+    useCase = new CancelScheduledTransactionUseCase(
+      getTransactionRepositoryStub,
+      saveTransactionRepositoryStub,
+      budgetAuthorizationServiceStub,
+      eventPublisherStub,
+    );
+  });
+
+  it('should cancel scheduled transaction successfully', async () => {
+    const dto: CancelScheduledTransactionDto = {
+      id: mockTransaction.id,
+      userId: 'user',
+      reason: 'Motivo',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasData).toBe(true);
+    expect(mockTransaction.isCancelled).toBe(true);
+    expect(eventPublisherStub.publishManyCalls).toHaveLength(1);
+  });
+
+  it('should return error when transaction not found', async () => {
+    getTransactionRepositoryStub.shouldReturnNull = true;
+
+    const dto: CancelScheduledTransactionDto = {
+      id: 'any',
+      userId: 'user',
+      reason: 'Motivo',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(TransactionNotFoundError);
+  });
+
+  it('should return error when user has no permission', async () => {
+    budgetAuthorizationServiceStub.mockHasAccess = false;
+
+    const dto: CancelScheduledTransactionDto = {
+      id: mockTransaction.id,
+      userId: 'user',
+      reason: 'Motivo',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(InsufficientPermissionsError);
+  });
+
+  it('should return error when save repository fails', async () => {
+    saveTransactionRepositoryStub.shouldFail = true;
+
+    const dto: CancelScheduledTransactionDto = {
+      id: mockTransaction.id,
+      userId: 'user',
+      reason: 'Motivo',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(TransactionPersistenceFailedError);
+  });
+
+  it('should return error when reason is invalid', async () => {
+    const dto: CancelScheduledTransactionDto = {
+      id: mockTransaction.id,
+      userId: 'user',
+      reason: ' ',
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+  });
+});

--- a/src/application/use-cases/transaction/cancel-scheduled-transaction/CancelScheduledTransactionUseCase.ts
+++ b/src/application/use-cases/transaction/cancel-scheduled-transaction/CancelScheduledTransactionUseCase.ts
@@ -1,0 +1,82 @@
+import { CancellationReason } from '@domain/aggregates/transaction/value-objects/cancellation-reason/CancellationReason';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IGetTransactionRepository } from '../../../contracts/repositories/transaction/IGetTransactionRepository';
+import { ISaveTransactionRepository } from '../../../contracts/repositories/transaction/ISaveTransactionRepository';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionNotFoundError } from '../../../shared/errors/TransactionNotFoundError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+import { CancelScheduledTransactionDto } from './CancelScheduledTransactionDto';
+
+export class CancelScheduledTransactionUseCase
+  implements IUseCase<CancelScheduledTransactionDto>
+{
+  constructor(
+    private readonly getTransactionRepository: IGetTransactionRepository,
+    private readonly saveTransactionRepository: ISaveTransactionRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(
+    dto: CancelScheduledTransactionDto,
+  ): Promise<Either<DomainError | ApplicationError, UseCaseResponse>> {
+    const transactionResult = await this.getTransactionRepository.execute(
+      dto.id,
+    );
+
+    if (transactionResult.hasError || !transactionResult.data) {
+      return Either.errors([new TransactionNotFoundError()]);
+    }
+
+    const transaction = transactionResult.data;
+
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      transaction.budgetId,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors(authResult.errors);
+    }
+
+    if (!authResult.data) {
+      return Either.error(new InsufficientPermissionsError());
+    }
+
+    const reasonVo = CancellationReason.create(dto.reason);
+
+    if (reasonVo.hasError) {
+      return Either.errors(reasonVo.errors);
+    }
+
+    const cancelResult = transaction.cancel(reasonVo);
+
+    if (cancelResult.hasError) {
+      return Either.errors(cancelResult.errors);
+    }
+
+    const saveResult =
+      await this.saveTransactionRepository.execute(transaction);
+
+    if (saveResult.hasError) {
+      return Either.error(new TransactionPersistenceFailedError());
+    }
+
+    if (transaction.hasEvents()) {
+      try {
+        await this.eventPublisher.publishMany(transaction.getEvents());
+        transaction.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success({ id: transaction.id });
+  }
+}

--- a/src/domain/aggregates/transaction/errors/InvalidCancellationReasonError.ts
+++ b/src/domain/aggregates/transaction/errors/InvalidCancellationReasonError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidCancellationReasonError extends DomainError {
+  constructor() {
+    super('Cancellation reason must be between 3 and 255 characters');
+    this.name = 'InvalidCancellationReasonError';
+    this.fieldName = 'reason';
+  }
+}

--- a/src/domain/aggregates/transaction/errors/TransactionAlreadyExecutedError.ts
+++ b/src/domain/aggregates/transaction/errors/TransactionAlreadyExecutedError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class TransactionAlreadyExecutedError extends DomainError {
+  constructor() {
+    super('Transaction has already been executed');
+  }
+}

--- a/src/domain/aggregates/transaction/errors/TransactionNotScheduledError.ts
+++ b/src/domain/aggregates/transaction/errors/TransactionNotScheduledError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class TransactionNotScheduledError extends DomainError {
+  constructor() {
+    super('Transaction is not scheduled');
+  }
+}

--- a/src/domain/aggregates/transaction/events/ScheduledTransactionCancelledEvent.spec.ts
+++ b/src/domain/aggregates/transaction/events/ScheduledTransactionCancelledEvent.spec.ts
@@ -1,0 +1,40 @@
+import { ScheduledTransactionCancelledEvent } from './ScheduledTransactionCancelledEvent';
+import { TransactionTypeEnum } from '../value-objects/transaction-type/TransactionType';
+
+describe('ScheduledTransactionCancelledEvent', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should create event with all data', () => {
+    const event = new ScheduledTransactionCancelledEvent(
+      'tx-1',
+      'acc-1',
+      'budget-1',
+      100,
+      TransactionTypeEnum.EXPENSE,
+      'Reason',
+      new Date('2024-01-02T00:00:00.000Z'),
+      'cat-1',
+      'cc-1',
+      new Date('2024-01-10T00:00:00.000Z'),
+    );
+
+    expect(event.aggregateId).toBe('tx-1');
+    expect(event.accountId).toBe('acc-1');
+    expect(event.budgetId).toBe('budget-1');
+    expect(event.amount).toBe(100);
+    expect(event.type).toBe(TransactionTypeEnum.EXPENSE);
+    expect(event.reason).toBe('Reason');
+    expect(event.cancelledAt).toEqual(new Date('2024-01-02T00:00:00.000Z'));
+    expect(event.categoryId).toBe('cat-1');
+    expect(event.creditCardId).toBe('cc-1');
+    expect(event.transactionDate).toEqual(new Date('2024-01-10T00:00:00.000Z'));
+    expect(event.occurredOn).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+  });
+});

--- a/src/domain/aggregates/transaction/events/ScheduledTransactionCancelledEvent.ts
+++ b/src/domain/aggregates/transaction/events/ScheduledTransactionCancelledEvent.ts
@@ -1,0 +1,19 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+import { TransactionTypeEnum } from '../value-objects/transaction-type/TransactionType';
+
+export class ScheduledTransactionCancelledEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly accountId: string,
+    public readonly budgetId: string,
+    public readonly amount: number,
+    public readonly type: TransactionTypeEnum,
+    public readonly reason: string,
+    public readonly cancelledAt: Date,
+    public readonly categoryId?: string,
+    public readonly creditCardId?: string,
+    public readonly transactionDate?: Date,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/transaction/value-objects/cancellation-reason/CancellationReason.spec.ts
+++ b/src/domain/aggregates/transaction/value-objects/cancellation-reason/CancellationReason.spec.ts
@@ -1,0 +1,34 @@
+import { InvalidCancellationReasonError } from '../../errors/InvalidCancellationReasonError';
+import { CancellationReason } from './CancellationReason';
+
+describe('CancellationReason', () => {
+  describe('create', () => {
+    it('deve criar um motivo válido', () => {
+      const vo = CancellationReason.create('Motivo válido');
+
+      expect(vo.hasError).toBe(false);
+      expect(vo.value?.reason).toBe('Motivo válido');
+    });
+
+    it('deve remover espaços extras', () => {
+      const vo = CancellationReason.create('  Teste  ');
+
+      expect(vo.hasError).toBe(false);
+      expect(vo.value?.reason).toBe('Teste');
+    });
+
+    it('deve falhar se motivo for muito curto', () => {
+      const vo = CancellationReason.create('ab');
+
+      expect(vo.hasError).toBe(true);
+      expect(vo.errors[0]).toEqual(new InvalidCancellationReasonError());
+    });
+
+    it('deve falhar se motivo for vazio', () => {
+      const vo = CancellationReason.create('   ');
+
+      expect(vo.hasError).toBe(true);
+      expect(vo.errors[0]).toEqual(new InvalidCancellationReasonError());
+    });
+  });
+});

--- a/src/domain/aggregates/transaction/value-objects/cancellation-reason/CancellationReason.ts
+++ b/src/domain/aggregates/transaction/value-objects/cancellation-reason/CancellationReason.ts
@@ -1,0 +1,51 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidCancellationReasonError } from '../../errors/InvalidCancellationReasonError';
+
+export type CancellationReasonValue = {
+  reason: string;
+};
+
+export class CancellationReason
+  implements IValueObject<CancellationReasonValue>
+{
+  private either = new Either<DomainError, CancellationReasonValue>();
+
+  private constructor(private _reason: string) {
+    this.validate();
+  }
+
+  get value(): CancellationReasonValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return (
+      vo instanceof CancellationReason &&
+      vo.value?.reason === this.value?.reason
+    );
+  }
+
+  static create(reason: string): CancellationReason {
+    return new CancellationReason(reason);
+  }
+
+  private validate() {
+    const trimmed = (this._reason ?? '').trim();
+
+    if (!trimmed || trimmed.length < 3 || trimmed.length > 255)
+      this.either.addError(new InvalidCancellationReasonError());
+
+    this.either.setData({ reason: trimmed });
+  }
+}


### PR DESCRIPTION
## Summary
- add docs for UC019 checklist and features
- implement cancellation reason value object
- add errors and scheduled transaction cancelled event
- update Transaction aggregate to support cancellation with reason and event
- implement CancelScheduledTransaction use case
- provide unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2a9aad00832394925aaa3a296efe