### PR TITLE
Implement UC016 Register Past Transaction

### DIFF
--- a/src/application/shared/tests/stubs/GetCategoryByIdRepositoryStub.ts
+++ b/src/application/shared/tests/stubs/GetCategoryByIdRepositoryStub.ts
@@ -1,0 +1,27 @@
+import { Category } from '@domain/aggregates/category/category-entity/Category';
+import { Either } from '@either';
+
+import { IGetCategoryByIdRepository } from '../../../contracts/repositories/category/IGetCategoryByIdRepository';
+import { RepositoryError } from '../../errors/RepositoryError';
+
+export class GetCategoryByIdRepositoryStub implements IGetCategoryByIdRepository {
+  public shouldFail = false;
+  public shouldReturnNull = false;
+  public executeCalls: string[] = [];
+  public mockCategory: Category | null = null;
+
+  async execute(categoryId: string): Promise<Either<RepositoryError, Category | null>> {
+    this.executeCalls.push(categoryId);
+
+    if (this.shouldFail) {
+      return Either.error(new RepositoryError('Repository failure'));
+    }
+
+    if (this.shouldReturnNull) {
+      return Either.success(null);
+    }
+
+    return Either.success(this.mockCategory);
+  }
+}
+

--- a/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionDto.ts
+++ b/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionDto.ts
@@ -1,0 +1,12 @@
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+
+export interface RegisterPastTransactionDto {
+  userId: string;
+  description: string;
+  amount: number;
+  type: TransactionTypeEnum;
+  accountId: string;
+  categoryId: string;
+  budgetId: string;
+  transactionDate: Date;
+}

--- a/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.spec.ts
+++ b/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.spec.ts
@@ -1,0 +1,170 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { AccountTypeEnum } from '@domain/aggregates/account/value-objects/account-type/AccountType';
+import { Category } from '@domain/aggregates/category/category-entity/Category';
+import { CategoryTypeEnum } from '@domain/aggregates/category/value-objects/category-type/CategoryType';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+import { Either } from '@either';
+
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { CategoryNotFoundError } from '../../../shared/errors/CategoryNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionCreationFailedError } from '../../../shared/errors/TransactionCreationFailedError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { AccountPersistenceFailedError } from '../../../shared/errors/AccountPersistenceFailedError';
+import { AddTransactionRepositoryStub } from '../../../shared/tests/stubs/AddTransactionRepositoryStub';
+import { SaveAccountRepositoryStub } from '../../../shared/tests/stubs/SaveAccountRepositoryStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { GetCategoryByIdRepositoryStub } from '../../../shared/tests/stubs/GetCategoryByIdRepositoryStub';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { RegisterPastTransactionDto } from './RegisterPastTransactionDto';
+import { RegisterPastTransactionUseCase } from './RegisterPastTransactionUseCase';
+
+const makeAccount = () =>
+  Account.create({
+    name: 'Conta',
+    type: AccountTypeEnum.CHECKING_ACCOUNT,
+    budgetId: EntityId.create().value!.id,
+    initialBalance: 1000,
+  }).data!;
+
+const makeCategory = (budgetId: string) =>
+  Category.create({
+    name: 'Cat',
+    type: CategoryTypeEnum.EXPENSE,
+    budgetId,
+  }).data!;
+
+const makeDto = (
+  accountId: string,
+  categoryId: string,
+  budgetId: string,
+): RegisterPastTransactionDto => ({
+  userId: EntityId.create().value!.id,
+  description: 'Compra',
+  amount: 500,
+  type: TransactionTypeEnum.EXPENSE,
+  accountId,
+  categoryId,
+  budgetId,
+  transactionDate: new Date(Date.now() - 86400000),
+});
+
+describe('RegisterPastTransactionUseCase', () => {
+  let useCase: RegisterPastTransactionUseCase;
+  let addTransactionRepository: AddTransactionRepositoryStub;
+  let saveAccountRepository: SaveAccountRepositoryStub;
+  let getAccountRepository: GetAccountRepositoryStub;
+  let getCategoryRepository: GetCategoryByIdRepositoryStub;
+  let budgetAuthorizationService: BudgetAuthorizationServiceStub;
+  let eventPublisher: EventPublisherStub;
+  let account: Account;
+  let category: Category;
+
+  beforeEach(() => {
+    addTransactionRepository = new AddTransactionRepositoryStub();
+    saveAccountRepository = new SaveAccountRepositoryStub();
+    getAccountRepository = new GetAccountRepositoryStub();
+    getCategoryRepository = new GetCategoryByIdRepositoryStub();
+    budgetAuthorizationService = new BudgetAuthorizationServiceStub();
+    eventPublisher = new EventPublisherStub();
+
+    useCase = new RegisterPastTransactionUseCase(
+      addTransactionRepository,
+      saveAccountRepository,
+      getAccountRepository,
+      getCategoryRepository,
+      budgetAuthorizationService,
+      eventPublisher,
+    );
+
+    account = makeAccount();
+    category = makeCategory(account.budgetId!);
+    getAccountRepository.mockAccount = account;
+    getCategoryRepository.mockCategory = category;
+  });
+
+  it('should register past transaction and update account balance', async () => {
+    const dto = makeDto(account.id, category.id, account.budgetId!);
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(false);
+    expect(account.balance).toBe(500); // 1000 - 500
+    expect(saveAccountRepository.executeCalls.length).toBe(1);
+  });
+
+  it('should return error when account not found', async () => {
+    getAccountRepository.shouldReturnNull = true;
+    const dto = makeDto(EntityId.create().value!.id, category.id, account.budgetId!);
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new AccountNotFoundError());
+  });
+
+  it('should return error when category not found', async () => {
+    getCategoryRepository.shouldReturnNull = true;
+    const dto = makeDto(account.id, EntityId.create().value!.id, account.budgetId!);
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new CategoryNotFoundError());
+  });
+
+  it('should return error when unauthorized', async () => {
+    budgetAuthorizationService.mockHasAccess = false;
+    const dto = makeDto(account.id, category.id, account.budgetId!);
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new InsufficientPermissionsError());
+  });
+
+  it('should return error when transaction creation fails', async () => {
+    const dto = makeDto(account.id, category.id, account.budgetId!);
+    dto.transactionDate = new Date(Date.now() + 86400000); // future
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(TransactionCreationFailedError);
+  });
+
+  it('should return error when save account repository fails', async () => {
+    saveAccountRepository.shouldFail = true;
+    const dto = makeDto(account.id, category.id, account.budgetId!);
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new AccountPersistenceFailedError());
+  });
+
+  it('should return error when add transaction repository fails', async () => {
+    jest.spyOn(addTransactionRepository, 'execute').mockResolvedValueOnce(
+      Either.errors([new TransactionPersistenceFailedError()]),
+    );
+    const dto = makeDto(account.id, category.id, account.budgetId!);
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new TransactionPersistenceFailedError());
+  });
+
+  it('should return error when account repository fails', async () => {
+    getAccountRepository.shouldFail = true;
+    const dto = makeDto(account.id, category.id, account.budgetId!);
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new AccountRepositoryError());
+  });
+});

--- a/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.ts
+++ b/src/application/use-cases/transaction/register-past-transaction/RegisterPastTransactionUseCase.ts
@@ -1,0 +1,120 @@
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IAddTransactionRepository } from '../../../contracts/repositories/transaction/IAddTransactionRepository';
+import { ISaveAccountRepository } from '../../../contracts/repositories/account/ISaveAccountRepository';
+import { IGetAccountRepository } from '../../../contracts/repositories/account/IGetAccountRepository';
+import { IGetCategoryByIdRepository } from '../../../contracts/repositories/category/IGetCategoryByIdRepository';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { CategoryNotFoundError } from '../../../shared/errors/CategoryNotFoundError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { TransactionCreationFailedError } from '../../../shared/errors/TransactionCreationFailedError';
+import { TransactionPersistenceFailedError } from '../../../shared/errors/TransactionPersistenceFailedError';
+import { AccountPersistenceFailedError } from '../../../shared/errors/AccountPersistenceFailedError';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+import { RegisterPastTransactionDto } from './RegisterPastTransactionDto';
+
+export class RegisterPastTransactionUseCase
+  implements IUseCase<RegisterPastTransactionDto>
+{
+  constructor(
+    private readonly addTransactionRepository: IAddTransactionRepository,
+    private readonly saveAccountRepository: ISaveAccountRepository,
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly getCategoryRepository: IGetCategoryByIdRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(
+    dto: RegisterPastTransactionDto,
+  ): Promise<Either<DomainError | ApplicationError, UseCaseResponse>> {
+    const accountResult = await this.getAccountRepository.execute(dto.accountId);
+
+    if (accountResult.hasError) {
+      return Either.errors([new AccountRepositoryError()]);
+    }
+
+    if (!accountResult.data) {
+      return Either.errors([new AccountNotFoundError()]);
+    }
+
+    const account = accountResult.data;
+
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      account.budgetId!,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors(authResult.errors);
+    }
+
+    if (!authResult.data) {
+      return Either.errors([new InsufficientPermissionsError()]);
+    }
+
+    const categoryResult = await this.getCategoryRepository.execute(dto.categoryId);
+    if (categoryResult.hasError) {
+      return Either.errors(categoryResult.errors);
+    }
+
+    if (!categoryResult.data) {
+      return Either.errors([new CategoryNotFoundError()]);
+    }
+
+    const transactionResult = Transaction.createPastTransaction({
+      description: dto.description,
+      amount: dto.amount,
+      type: dto.type,
+      accountId: dto.accountId,
+      categoryId: dto.categoryId,
+      budgetId: dto.budgetId,
+      transactionDate: dto.transactionDate,
+    });
+
+    if (transactionResult.hasError) {
+      const message = transactionResult.errors.map((e) => e.message).join('; ');
+      return Either.errors([new TransactionCreationFailedError(message)]);
+    }
+
+    const transaction = transactionResult.data!;
+
+    const balanceResult =
+      transaction.type === TransactionTypeEnum.INCOME
+        ? account.addAmount(transaction.amount)
+        : account.subtractAmount(transaction.amount);
+
+    if (balanceResult.hasError) {
+      return Either.errors(balanceResult.errors);
+    }
+
+    const saveAccountResult = await this.saveAccountRepository.execute(account);
+    if (saveAccountResult.hasError) {
+      return Either.errors([new AccountPersistenceFailedError()]);
+    }
+
+    const saveTransactionResult = await this.addTransactionRepository.execute(transaction);
+    if (saveTransactionResult.hasError) {
+      return Either.errors([new TransactionPersistenceFailedError()]);
+    }
+
+    const events = transaction.getEvents();
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        transaction.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success({ id: transaction.id });
+  }
+}

--- a/src/domain/aggregates/transaction/errors/InvalidTransactionDateError.ts
+++ b/src/domain/aggregates/transaction/errors/InvalidTransactionDateError.ts
@@ -1,0 +1,9 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidTransactionDateError extends DomainError {
+  constructor() {
+    super('Transaction date must be a valid past date within one year');
+    this.name = 'InvalidTransactionDateError';
+    this.fieldName = 'transactionDate';
+  }
+}


### PR DESCRIPTION
## Summary
- add InvalidTransactionDateError for transaction aggregate
- support creating past transactions via Transaction.createPastTransaction
- implement RegisterPastTransactionUseCase with DTO and tests
- add repository stub for getting category by id
- cover new factory method and use case in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2a85662083239c141ad650148fa3