### PR TITLE
Implement account reconciliation use case

### DIFF
--- a/src/application/use-cases/account/reconcile-account-balance/ReconcileAccountBalanceDto.ts
+++ b/src/application/use-cases/account/reconcile-account-balance/ReconcileAccountBalanceDto.ts
@@ -1,0 +1,6 @@
+export interface ReconcileAccountBalanceDto {
+  userId: string;
+  accountId: string;
+  newBalance: number;
+  justification: string;
+}

--- a/src/application/use-cases/account/reconcile-account-balance/ReconcileAccountBalanceUseCase.spec.ts
+++ b/src/application/use-cases/account/reconcile-account-balance/ReconcileAccountBalanceUseCase.spec.ts
@@ -1,0 +1,141 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { AccountReconciledEvent } from '@domain/aggregates/account/events/AccountReconciledEvent';
+import { AccountTypeEnum } from '@domain/aggregates/account/value-objects/account-type/AccountType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountPersistenceFailedError } from '../../../shared/errors/AccountPersistenceFailedError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { AccountUpdateFailedError } from '../../../shared/errors/AccountUpdateFailedError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { BudgetAuthorizationServiceStub } from '../../../shared/tests/stubs/BudgetAuthorizationServiceStub';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { SaveAccountRepositoryStub } from '../../../shared/tests/stubs/SaveAccountRepositoryStub';
+import { ReconcileAccountBalanceDto } from './ReconcileAccountBalanceDto';
+import { ReconcileAccountBalanceUseCase } from './ReconcileAccountBalanceUseCase';
+
+describe('ReconcileAccountBalanceUseCase', () => {
+  let useCase: ReconcileAccountBalanceUseCase;
+  let getAccountRepositoryStub: GetAccountRepositoryStub;
+  let saveAccountRepositoryStub: SaveAccountRepositoryStub;
+  let budgetAuthorizationServiceStub: BudgetAuthorizationServiceStub;
+  let eventPublisherStub: EventPublisherStub;
+  let mockAccount: Account;
+  let budgetId: string;
+  const userId = EntityId.create().value!.id;
+
+  beforeEach(() => {
+    getAccountRepositoryStub = new GetAccountRepositoryStub();
+    saveAccountRepositoryStub = new SaveAccountRepositoryStub();
+    budgetAuthorizationServiceStub = new BudgetAuthorizationServiceStub();
+    eventPublisherStub = new EventPublisherStub();
+
+    budgetId = EntityId.create().value!.id;
+    const accountResult = Account.create({
+      name: 'Acc',
+      type: AccountTypeEnum.CHECKING_ACCOUNT,
+      budgetId,
+      initialBalance: 1000,
+    });
+    if (accountResult.hasError) throw new Error('setup error');
+    mockAccount = accountResult.data!;
+    mockAccount.clearEvents();
+    getAccountRepositoryStub.mockAccount = mockAccount;
+
+    useCase = new ReconcileAccountBalanceUseCase(
+      getAccountRepositoryStub,
+      saveAccountRepositoryStub,
+      budgetAuthorizationServiceStub,
+      eventPublisherStub,
+    );
+  });
+
+  const validDto = (): ReconcileAccountBalanceDto => ({
+    userId,
+    accountId: mockAccount.id,
+    newBalance: 1200,
+    justification: 'Ajuste bancário',
+  });
+
+  describe('execute', () => {
+    it('should reconcile account and publish event', async () => {
+      const dto = validDto();
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasData).toBe(true);
+      expect(eventPublisherStub.publishManyCalls.length).toBe(1);
+      const events = eventPublisherStub.publishManyCalls[0];
+      expect(events[0]).toBeInstanceOf(AccountReconciledEvent);
+    });
+
+    it('should return error when account not found', async () => {
+      getAccountRepositoryStub.shouldReturnNull = true;
+      const dto = validDto();
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new AccountNotFoundError());
+    });
+
+    it('should return error when repository fails', async () => {
+      getAccountRepositoryStub.shouldFail = true;
+      const dto = validDto();
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new AccountRepositoryError());
+    });
+
+    it('should return error when user has no permission', async () => {
+      budgetAuthorizationServiceStub.mockHasAccess = false;
+      const dto = validDto();
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new InsufficientPermissionsError());
+    });
+
+    it('should return error when authorization service fails', async () => {
+      budgetAuthorizationServiceStub.shouldFail = true;
+      const dto = validDto();
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+    });
+
+    it('should return error when reconcile data invalid', async () => {
+      const dto = validDto();
+      dto.justification = 'short';
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toBeInstanceOf(AccountUpdateFailedError);
+    });
+
+    it('should return error when persistence fails', async () => {
+      saveAccountRepositoryStub.shouldFail = true;
+      const dto = validDto();
+
+      const result = await useCase.execute(dto);
+
+      expect(result.hasError).toBe(true);
+      expect(result.errors[0]).toEqual(new AccountPersistenceFailedError());
+    });
+
+    it('should call repositories with correct params', async () => {
+      const dto = validDto();
+
+      await useCase.execute(dto);
+
+      expect(getAccountRepositoryStub.executeCalls[0]).toBe(mockAccount.id);
+      expect(saveAccountRepositoryStub.executeCalls[0].id).toBe(mockAccount.id);
+    });
+  });
+});

--- a/src/application/use-cases/account/reconcile-account-balance/ReconcileAccountBalanceUseCase.ts
+++ b/src/application/use-cases/account/reconcile-account-balance/ReconcileAccountBalanceUseCase.ts
@@ -1,0 +1,97 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IEventPublisher } from '../../../contracts/events/IEventPublisher';
+import { IGetAccountRepository } from '../../../contracts/repositories/account/IGetAccountRepository';
+import { ISaveAccountRepository } from '../../../contracts/repositories/account/ISaveAccountRepository';
+import { IBudgetAuthorizationService } from '../../../services/authorization/IBudgetAuthorizationService';
+import { ApplicationError } from '../../../shared/errors/ApplicationError';
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { AccountPersistenceFailedError } from '../../../shared/errors/AccountPersistenceFailedError';
+import { AccountRepositoryError } from '../../../shared/errors/AccountRepositoryError';
+import { AccountUpdateFailedError } from '../../../shared/errors/AccountUpdateFailedError';
+import { InsufficientPermissionsError } from '../../../shared/errors/InsufficientPermissionsError';
+import { IUseCase, UseCaseResponse } from '../../../shared/IUseCase';
+import { ReconcileAccountBalanceDto } from './ReconcileAccountBalanceDto';
+
+export class ReconcileAccountBalanceUseCase
+  implements IUseCase<ReconcileAccountBalanceDto>
+{
+  constructor(
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly saveAccountRepository: ISaveAccountRepository,
+    private readonly budgetAuthorizationService: IBudgetAuthorizationService,
+    private readonly eventPublisher: IEventPublisher,
+  ) {}
+
+  async execute(
+    dto: ReconcileAccountBalanceDto,
+  ): Promise<Either<ApplicationError | DomainError, UseCaseResponse>> {
+    const accountResult = await this.getAccountRepository.execute(dto.accountId);
+
+    if (accountResult.hasError) {
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>([
+        new AccountRepositoryError(),
+      ]);
+    }
+
+    if (!accountResult.data) {
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>([
+        new AccountNotFoundError(),
+      ]);
+    }
+
+    const account = accountResult.data as Account;
+
+    const authResult = await this.budgetAuthorizationService.canAccessBudget(
+      dto.userId,
+      account.budgetId!,
+    );
+
+    if (authResult.hasError) {
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>(
+        authResult.errors,
+      );
+    }
+
+    if (!authResult.data) {
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>([
+        new InsufficientPermissionsError(),
+      ]);
+    }
+
+    const reconcileResult = account.reconcile(dto.newBalance, dto.justification);
+
+    if (reconcileResult.hasError) {
+      const message = reconcileResult.errors
+        .map((e) => e.message)
+        .join('; ');
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>([
+        new AccountUpdateFailedError(message),
+      ]);
+    }
+
+    const saveResult = await this.saveAccountRepository.execute(account);
+
+    if (saveResult.hasError) {
+      return Either.errors<ApplicationError | DomainError, UseCaseResponse>([
+        new AccountPersistenceFailedError(),
+      ]);
+    }
+
+    const events = account.getEvents();
+    if (events.length > 0) {
+      try {
+        await this.eventPublisher.publishMany(events);
+        account.clearEvents();
+      } catch (error) {
+        console.error('Failed to publish events:', error);
+      }
+    }
+
+    return Either.success<ApplicationError | DomainError, UseCaseResponse>({
+      id: account.id,
+    });
+  }
+}

--- a/src/domain/aggregates/account/errors/InvalidReconciliationAmountError.ts
+++ b/src/domain/aggregates/account/errors/InvalidReconciliationAmountError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidReconciliationAmountError extends DomainError {
+  constructor(value: unknown) {
+    super(`Invalid reconciliation amount: ${value}`);
+  }
+}

--- a/src/domain/aggregates/account/errors/InvalidReconciliationJustificationError.ts
+++ b/src/domain/aggregates/account/errors/InvalidReconciliationJustificationError.ts
@@ -1,0 +1,7 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidReconciliationJustificationError extends DomainError {
+  constructor(value: string) {
+    super(`Invalid reconciliation justification: ${value}`);
+  }
+}

--- a/src/domain/aggregates/account/events/AccountReconciledEvent.spec.ts
+++ b/src/domain/aggregates/account/events/AccountReconciledEvent.spec.ts
@@ -1,0 +1,32 @@
+import { AccountReconciledEvent } from './AccountReconciledEvent';
+
+describe('AccountReconciledEvent', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should create event with provided properties', () => {
+    const event = new AccountReconciledEvent(
+      'acc-id',
+      'budget-id',
+      100,
+      150,
+      50,
+      'ajuste',
+    );
+
+    expect(event.aggregateId).toBe('acc-id');
+    expect(event.budgetId).toBe('budget-id');
+    expect(event.previousBalance).toBe(100);
+    expect(event.newBalance).toBe(150);
+    expect(event.difference).toBe(50);
+    expect(event.justification).toBe('ajuste');
+    expect(event.occurredOn).toEqual(new Date('2025-01-01T00:00:00.000Z'));
+    expect(event.eventVersion).toBe(1);
+  });
+});

--- a/src/domain/aggregates/account/events/AccountReconciledEvent.ts
+++ b/src/domain/aggregates/account/events/AccountReconciledEvent.ts
@@ -1,0 +1,14 @@
+import { DomainEvent } from '../../../shared/events/DomainEvent';
+
+export class AccountReconciledEvent extends DomainEvent {
+  constructor(
+    aggregateId: string,
+    public readonly budgetId: string,
+    public readonly previousBalance: number,
+    public readonly newBalance: number,
+    public readonly difference: number,
+    public readonly justification: string,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/src/domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount.spec.ts
+++ b/src/domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount.spec.ts
@@ -1,0 +1,42 @@
+import { InvalidReconciliationAmountError } from '../../errors/InvalidReconciliationAmountError';
+import { ReconciliationAmount } from './ReconciliationAmount';
+
+describe('ReconciliationAmount', () => {
+  it('should create a valid value for positive amount', () => {
+    const vo = ReconciliationAmount.create(100);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.cents).toBe(100);
+  });
+
+  it('should create a valid value for negative amount', () => {
+    const vo = ReconciliationAmount.create(-50);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.cents).toBe(-50);
+  });
+
+  it('should return error for zero amount', () => {
+    const vo = ReconciliationAmount.create(0);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidReconciliationAmountError(0));
+  });
+
+  it('should return error for non integer value', () => {
+    const vo = ReconciliationAmount.create(10.5);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidReconciliationAmountError(10.5));
+  });
+
+  it('should return error for NaN', () => {
+    const vo = ReconciliationAmount.create(NaN);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(new InvalidReconciliationAmountError(NaN));
+  });
+
+  it('should compare equality correctly', () => {
+    const vo1 = ReconciliationAmount.create(100);
+    const vo2 = ReconciliationAmount.create(100);
+    const vo3 = ReconciliationAmount.create(-100);
+    expect(vo1.equals(vo2)).toBe(true);
+    expect(vo1.equals(vo3)).toBe(false);
+  });
+});

--- a/src/domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount.ts
+++ b/src/domain/aggregates/account/value-objects/reconciliation-amount/ReconciliationAmount.ts
@@ -1,0 +1,57 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidReconciliationAmountError } from '../../errors/InvalidReconciliationAmountError';
+
+export type ReconciliationAmountValue = {
+  cents: number;
+};
+
+export class ReconciliationAmount implements IValueObject<ReconciliationAmountValue> {
+  private either = new Either<DomainError, ReconciliationAmountValue>();
+
+  private constructor(private _cents: number) {
+    this.validate();
+  }
+
+  get value(): ReconciliationAmountValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return vo instanceof ReconciliationAmount && vo.value?.cents === this.value?.cents;
+  }
+
+  static create(amount: number): ReconciliationAmount {
+    return new ReconciliationAmount(amount);
+  }
+
+  get asMonetaryValue(): number {
+    return (this.value?.cents ?? 0) / 100;
+  }
+
+  private validate() {
+    if (typeof this._cents !== 'number' || isNaN(this._cents) || !isFinite(this._cents)) {
+      this.either.addError(new InvalidReconciliationAmountError(this._cents));
+    }
+
+    if (this._cents === 0) {
+      this.either.addError(new InvalidReconciliationAmountError(this._cents));
+    }
+
+    if (!Number.isInteger(this._cents)) {
+      this.either.addError(new InvalidReconciliationAmountError(this._cents));
+    }
+
+    this.either.setData({ cents: this._cents });
+  }
+}

--- a/src/domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification.spec.ts
+++ b/src/domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification.spec.ts
@@ -1,0 +1,37 @@
+import { InvalidReconciliationJustificationError } from '../../errors/InvalidReconciliationJustificationError';
+import { ReconciliationJustification } from './ReconciliationJustification';
+
+describe('ReconciliationJustification', () => {
+  it('should create valid justification', () => {
+    const text = 'Ajuste de saldo devido a taxa bancária';
+    const vo = ReconciliationJustification.create(text);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.justification).toBe(text);
+  });
+
+  it('should return error when text is too short', () => {
+    const vo = ReconciliationJustification.create('short');
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(
+      new InvalidReconciliationJustificationError('short'),
+    );
+  });
+
+  it('should return error when text is too long', () => {
+    const long = 'a'.repeat(501);
+    const vo = ReconciliationJustification.create(long);
+    expect(vo.hasError).toBe(true);
+    expect(vo.errors[0]).toEqual(
+      new InvalidReconciliationJustificationError(long),
+    );
+  });
+
+  it('should compare equality correctly', () => {
+    const text = 'Reconciliação mensal de extrato';
+    const vo1 = ReconciliationJustification.create(text);
+    const vo2 = ReconciliationJustification.create(text);
+    const vo3 = ReconciliationJustification.create('Outra justificativa diferente');
+    expect(vo1.equals(vo2)).toBe(true);
+    expect(vo1.equals(vo3)).toBe(false);
+  });
+});

--- a/src/domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification.ts
+++ b/src/domain/aggregates/account/value-objects/reconciliation-justification/ReconciliationJustification.ts
@@ -1,0 +1,58 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidReconciliationJustificationError } from '../../errors/InvalidReconciliationJustificationError';
+
+export type ReconciliationJustificationValue = {
+  justification: string;
+};
+
+export class ReconciliationJustification implements IValueObject<ReconciliationJustificationValue> {
+  private either = new Either<DomainError, ReconciliationJustificationValue>();
+
+  private static readonly MIN_LENGTH = 10;
+  private static readonly MAX_LENGTH = 500;
+
+  private constructor(private _justification: string) {
+    this.validate();
+  }
+
+  get value(): ReconciliationJustificationValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return (
+      vo instanceof ReconciliationJustification &&
+      vo.value?.justification === this.value?.justification
+    );
+  }
+
+  static create(text: string): ReconciliationJustification {
+    return new ReconciliationJustification(text);
+  }
+
+  private validate() {
+    const trimmed = this._justification?.trim();
+    if (
+      !trimmed ||
+      trimmed.length < ReconciliationJustification.MIN_LENGTH ||
+      trimmed.length > ReconciliationJustification.MAX_LENGTH
+    ) {
+      this.either.addError(
+        new InvalidReconciliationJustificationError(this._justification),
+      );
+    }
+
+    this.either.setData({ justification: this._justification });
+  }
+}


### PR DESCRIPTION
## Summary
- add VO for reconciliation amount and justification
- support balance reconciliation on Account entity
- raise AccountReconciledEvent
- add ReconcileAccountBalanceUseCase
- cover new behaviour with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2a4a8058832383119eb327086c63