### PR TITLE
Implement credit card bill payment

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,3 @@
+# Features
+
+- [x] UC031 - Marcar Fatura como Paga (src/application/use-cases/credit-card-bill/mark-credit-card-bill-as-paid)

--- a/docs/tasks/UC031-marcar-fatura-como-paga.md
+++ b/docs/tasks/UC031-marcar-fatura-como-paga.md
@@ -1,0 +1,11 @@
+# UC031 - Marcar Fatura como Paga
+
+- [x] PaymentAmount value object com validações
+- [x] PaymentDate value object com validações
+- [x] Enum BillStatus com status PAID
+- [x] Método `CreditCardBill.markAsPaid`
+- [x] Caso de uso com Unit of Work
+- [x] Débito automático da conta
+- [x] Criação de transação de débito
+- [x] Validação de saldo suficiente
+- [x] Testes cobrindo cenários principais

--- a/src/application/contracts/unit-of-works/IPayCreditCardBillUnitOfWork.ts
+++ b/src/application/contracts/unit-of-works/IPayCreditCardBillUnitOfWork.ts
@@ -1,0 +1,13 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { CreditCardBill } from '@domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+export interface IPayCreditCardBillUnitOfWork {
+  executePayment(params: {
+    account: Account;
+    bill: CreditCardBill;
+    transaction: Transaction;
+  }): Promise<Either<DomainError, void>>;
+}

--- a/src/application/shared/tests/stubs/IPayCreditCardBillUnitOfWorkStub.ts
+++ b/src/application/shared/tests/stubs/IPayCreditCardBillUnitOfWorkStub.ts
@@ -1,0 +1,24 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { CreditCardBill } from '@domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { DomainError } from '@domain/shared/DomainError';
+import { Either } from '@either';
+
+import { IPayCreditCardBillUnitOfWork } from '../../../contracts/unit-of-works/IPayCreditCardBillUnitOfWork';
+
+export class IPayCreditCardBillUnitOfWorkStub implements IPayCreditCardBillUnitOfWork {
+  public executePaymentCalls: Array<{
+    account: Account;
+    bill: CreditCardBill;
+    transaction: Transaction;
+  }> = [];
+
+  async executePayment(params: {
+    account: Account;
+    bill: CreditCardBill;
+    transaction: Transaction;
+  }): Promise<Either<DomainError, void>> {
+    this.executePaymentCalls.push(params);
+    return Either.success(undefined);
+  }
+}

--- a/src/application/use-cases/credit-card-bill/mark-credit-card-bill-as-paid/MarkCreditCardBillAsPaidDTO.ts
+++ b/src/application/use-cases/credit-card-bill/mark-credit-card-bill-as-paid/MarkCreditCardBillAsPaidDTO.ts
@@ -1,0 +1,12 @@
+export interface MarkCreditCardBillAsPaidRequestDTO {
+  billId: string;
+  accountId: string;
+  paymentAmount: number;
+  paymentDate: Date;
+}
+
+export interface MarkCreditCardBillAsPaidResponseDTO {
+  id: string;
+  paidAt: Date;
+  status: string;
+}

--- a/src/application/use-cases/credit-card-bill/mark-credit-card-bill-as-paid/MarkCreditCardBillAsPaidUseCase.spec.ts
+++ b/src/application/use-cases/credit-card-bill/mark-credit-card-bill-as-paid/MarkCreditCardBillAsPaidUseCase.spec.ts
@@ -1,0 +1,135 @@
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { AccountTypeEnum } from '@domain/aggregates/account/value-objects/account-type/AccountType';
+import { CreditCardBill, RestoreCreditCardBillDTO } from '@domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill';
+import { BillStatusEnum } from '@domain/aggregates/credit-card-bill/value-objects/bill-status/BillStatus';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { EntityId } from '@domain/shared/value-objects/entity-id/EntityId';
+
+import { AccountNotFoundError } from '../../../shared/errors/AccountNotFoundError';
+import { CreditCardBillNotFoundError } from '../../../shared/errors/CreditCardBillNotFoundError';
+import { EventPublisherStub } from '../../../shared/tests/stubs/EventPublisherStub';
+import { GetAccountRepositoryStub } from '../../../shared/tests/stubs/GetAccountRepositoryStub';
+import { GetCreditCardBillRepositoryStub } from '../../../shared/tests/stubs/GetCreditCardBillRepositoryStub';
+import { IPayCreditCardBillUnitOfWorkStub } from '../../../shared/tests/stubs/IPayCreditCardBillUnitOfWorkStub';
+import { InsufficientBalanceError } from '../../../../domain/aggregates/account/errors/InsufficientBalanceError';
+import { MarkCreditCardBillAsPaidRequestDTO } from './MarkCreditCardBillAsPaidDTO';
+import { MarkCreditCardBillAsPaidUseCase } from './MarkCreditCardBillAsPaidUseCase';
+
+const CATEGORY_ID = EntityId.create().value!.id;
+
+const makeAccount = () => {
+  return Account.create({
+    name: 'Conta',
+    type: AccountTypeEnum.CHECKING_ACCOUNT,
+    budgetId: EntityId.create().value!.id,
+    initialBalance: 60000,
+  }).data!;
+};
+
+const makeBill = (): CreditCardBill => {
+  const billData: RestoreCreditCardBillDTO = {
+    id: EntityId.create().value!.id,
+    creditCardId: EntityId.create().value!.id,
+    closingDate: new Date('2024-01-01'),
+    dueDate: new Date('2024-01-10'),
+    amount: 50000,
+    status: BillStatusEnum.OPEN,
+    isDeleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  return CreditCardBill.restore(billData).data!;
+};
+
+describe('MarkCreditCardBillAsPaidUseCase', () => {
+  let useCase: MarkCreditCardBillAsPaidUseCase;
+  let getBillRepo: GetCreditCardBillRepositoryStub;
+  let getAccountRepo: GetAccountRepositoryStub;
+  let uowStub: IPayCreditCardBillUnitOfWorkStub;
+  let eventPublisher: EventPublisherStub;
+  let account: Account;
+  let bill: CreditCardBill;
+
+  beforeEach(() => {
+    getBillRepo = new GetCreditCardBillRepositoryStub();
+    getAccountRepo = new GetAccountRepositoryStub();
+    uowStub = new IPayCreditCardBillUnitOfWorkStub();
+    eventPublisher = new EventPublisherStub();
+    useCase = new MarkCreditCardBillAsPaidUseCase(
+      getBillRepo,
+      getAccountRepo,
+      uowStub,
+      eventPublisher,
+      CATEGORY_ID,
+    );
+
+    account = makeAccount();
+    bill = makeBill();
+    getBillRepo.setCreditCardBill(bill);
+    getAccountRepo.mockAccount = account;
+  });
+
+  it('should pay bill successfully', async () => {
+    const dto: MarkCreditCardBillAsPaidRequestDTO = {
+      billId: bill.id,
+      accountId: account.id,
+      paymentAmount: 50000,
+      paymentDate: new Date(),
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasData).toBe(true);
+    expect(uowStub.executePaymentCalls).toHaveLength(1);
+    const payment = uowStub.executePaymentCalls[0];
+    expect(payment.account.id).toBe(account.id);
+    expect(payment.bill.id).toBe(bill.id);
+    expect(payment.transaction.type).toBe(TransactionTypeEnum.EXPENSE);
+  });
+
+  it('should return error when bill not found', async () => {
+    getBillRepo.setCreditCardBill(null);
+
+    const dto: MarkCreditCardBillAsPaidRequestDTO = {
+      billId: 'invalid',
+      accountId: account.id,
+      paymentAmount: 100,
+      paymentDate: new Date(),
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new CreditCardBillNotFoundError());
+  });
+
+  it('should return error when account not found', async () => {
+    getAccountRepo.mockAccount = null;
+
+    const dto: MarkCreditCardBillAsPaidRequestDTO = {
+      billId: bill.id,
+      accountId: 'invalid',
+      paymentAmount: 100,
+      paymentDate: new Date(),
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toEqual(new AccountNotFoundError());
+  });
+
+  it('should return error when insufficient balance', async () => {
+    const dto: MarkCreditCardBillAsPaidRequestDTO = {
+      billId: bill.id,
+      accountId: account.id,
+      paymentAmount: 200000,
+      paymentDate: new Date(),
+    };
+
+    const result = await useCase.execute(dto);
+
+    expect(result.hasError).toBe(true);
+    expect(result.errors[0]).toBeInstanceOf(InsufficientBalanceError);
+  });
+});

--- a/src/application/use-cases/credit-card-bill/mark-credit-card-bill-as-paid/MarkCreditCardBillAsPaidUseCase.ts
+++ b/src/application/use-cases/credit-card-bill/mark-credit-card-bill-as-paid/MarkCreditCardBillAsPaidUseCase.ts
@@ -1,0 +1,120 @@
+import { Either } from '@either';
+import { IUseCase } from '@application/shared/IUseCase';
+import { ApplicationError } from '@application/shared/errors/ApplicationError';
+import { CreditCardBillNotFoundError } from '@application/shared/errors/CreditCardBillNotFoundError';
+import { AccountNotFoundError } from '@application/shared/errors/AccountNotFoundError';
+import { InsufficientBalanceError } from '@domain/aggregates/account/errors/InsufficientBalanceError';
+import { CreditCardBill } from '@domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill';
+import { Account } from '@domain/aggregates/account/account-entity/Account';
+import { Transaction } from '@domain/aggregates/transaction/transaction-entity/Transaction';
+import { TransactionTypeEnum } from '@domain/aggregates/transaction/value-objects/transaction-type/TransactionType';
+import { DomainError } from '@domain/shared/DomainError';
+
+import { IEventPublisher } from '@application/contracts/events/IEventPublisher';
+import { IGetCreditCardBillRepository } from '@application/contracts/repositories/credit-card-bill/IGetCreditCardBillRepository';
+import { IGetAccountRepository } from '@application/contracts/repositories/account/IGetAccountRepository';
+import { IPayCreditCardBillUnitOfWork } from '@application/contracts/unit-of-works/IPayCreditCardBillUnitOfWork';
+import { MarkCreditCardBillAsPaidRequestDTO, MarkCreditCardBillAsPaidResponseDTO } from './MarkCreditCardBillAsPaidDTO';
+
+export class MarkCreditCardBillAsPaidUseCase
+  implements IUseCase<MarkCreditCardBillAsPaidRequestDTO>
+{
+  constructor(
+    private readonly getCreditCardBillRepository: IGetCreditCardBillRepository,
+    private readonly getAccountRepository: IGetAccountRepository,
+    private readonly unitOfWork: IPayCreditCardBillUnitOfWork,
+    private readonly eventPublisher: IEventPublisher,
+    private readonly paymentCategoryId: string,
+  ) {}
+
+  async execute(
+    request: MarkCreditCardBillAsPaidRequestDTO,
+  ): Promise<
+    Either<DomainError | ApplicationError, MarkCreditCardBillAsPaidResponseDTO>
+  > {
+    const billResult = await this.getCreditCardBillRepository.execute(
+      request.billId,
+    );
+
+    if (billResult.hasError) {
+      return Either.errors(billResult.errors);
+    }
+
+    const bill = billResult.data;
+    if (!bill) {
+      return Either.error(new CreditCardBillNotFoundError());
+    }
+
+    const accountResult = await this.getAccountRepository.execute(
+      request.accountId,
+    );
+
+    if (accountResult.hasError) {
+      return Either.errors(accountResult.errors);
+    }
+
+    const account = accountResult.data;
+    if (!account) {
+      return Either.error(new AccountNotFoundError());
+    }
+
+    if (!account.canSubtract(request.paymentAmount)) {
+      return Either.error(new InsufficientBalanceError());
+    }
+
+    const payResult = bill.markAsPaid(
+      request.paymentAmount,
+      request.paymentDate,
+    );
+
+    if (payResult.hasError) {
+      return Either.errors(payResult.errors);
+    }
+
+    const subtractResult = account.subtractAmount(request.paymentAmount);
+    if (subtractResult.hasError) {
+      return Either.errors(subtractResult.errors);
+    }
+
+    const transactionResult = Transaction.create({
+      description: 'Pagamento fatura',
+      amount: request.paymentAmount,
+      type: TransactionTypeEnum.EXPENSE,
+      transactionDate: request.paymentDate,
+      categoryId: this.paymentCategoryId,
+      budgetId: account.budgetId!,
+      accountId: account.id,
+    });
+
+    if (transactionResult.hasError) {
+      return Either.errors(transactionResult.errors);
+    }
+
+    const transaction = transactionResult.data!;
+
+    const uowResult = await this.unitOfWork.executePayment({
+      account,
+      bill,
+      transaction,
+    });
+
+    if (uowResult.hasError) {
+      return Either.errors(uowResult.errors);
+    }
+
+    const events = [...bill.getEvents(), ...transaction.getEvents()];
+    try {
+      if (events.length) await this.eventPublisher.publishMany(events);
+      bill.clearEvents();
+      transaction.clearEvents();
+    } catch (error) {
+      console.error('Failed to publish domain events:', error);
+    }
+
+    return Either.success({
+      id: bill.id,
+      paidAt: bill.paidAt!,
+      status: bill.status,
+    });
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill.spec.ts
+++ b/src/domain/aggregates/credit-card-bill/credit-card-bill-entity/CreditCardBill.spec.ts
@@ -171,7 +171,7 @@ describe('CreditCardBill', () => {
       });
 
       it('deve marcar a fatura como paga', () => {
-        const result = bill.markAsPaid();
+        const result = bill.markAsPaid(50000, new Date());
 
         expect(result.hasError).toBe(false);
         expect(bill.status).toBe(BillStatusEnum.PAID);
@@ -182,14 +182,19 @@ describe('CreditCardBill', () => {
         expect(events[0]).toBeInstanceOf(CreditCardBillPaidEvent);
       });
 
-      it('deve permitir marcar como paga múltiplas vezes sem erro', () => {
-        bill.markAsPaid();
+      it('deve retornar erro ao tentar pagar novamente', () => {
+        bill.markAsPaid(50000, new Date());
         bill.clearEvents();
-        const result = bill.markAsPaid();
+        const result = bill.markAsPaid(50000, new Date());
 
-        expect(result.hasError).toBe(false);
-        expect(bill.status).toBe(BillStatusEnum.PAID);
+        expect(result.hasError).toBe(true);
         expect(bill.getEvents()).toHaveLength(0);
+      });
+
+      it('deve retornar erro se a fatura não estiver OPEN', () => {
+        bill.markAsPaid(50000, new Date());
+        const result = bill.markAsPaid(50000, new Date());
+        expect(result.hasError).toBe(true);
       });
     });
 
@@ -207,7 +212,7 @@ describe('CreditCardBill', () => {
 
     describe('reopen', () => {
       it('deve reabrir fatura paga e emitir evento', () => {
-        bill.markAsPaid();
+        bill.markAsPaid(50000, new Date());
         bill.clearEvents();
         const result = bill.reopen();
         expect(result.hasError).toBe(false);

--- a/src/domain/aggregates/credit-card-bill/errors/InvalidPaymentAmountError.ts
+++ b/src/domain/aggregates/credit-card-bill/errors/InvalidPaymentAmountError.ts
@@ -1,0 +1,8 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidPaymentAmountError extends DomainError {
+  constructor() {
+    super('Invalid payment amount');
+    this.name = 'InvalidPaymentAmountError';
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/errors/InvalidPaymentDateError.ts
+++ b/src/domain/aggregates/credit-card-bill/errors/InvalidPaymentDateError.ts
@@ -1,0 +1,8 @@
+import { DomainError } from '../../../shared/DomainError';
+
+export class InvalidPaymentDateError extends DomainError {
+  constructor() {
+    super('Invalid payment date');
+    this.name = 'InvalidPaymentDateError';
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/value-objects/payment-amount/PaymentAmount.spec.ts
+++ b/src/domain/aggregates/credit-card-bill/value-objects/payment-amount/PaymentAmount.spec.ts
@@ -1,0 +1,24 @@
+import { PaymentAmount } from './PaymentAmount';
+
+describe('PaymentAmount', () => {
+  it('should create a valid payment amount', () => {
+    const vo = PaymentAmount.create(100);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.cents).toBe(100);
+  });
+
+  it('should return error for zero amount', () => {
+    const vo = PaymentAmount.create(0);
+    expect(vo.hasError).toBe(true);
+  });
+
+  it('should return error for negative amount', () => {
+    const vo = PaymentAmount.create(-10);
+    expect(vo.hasError).toBe(true);
+  });
+
+  it('should return error for amount with more than two decimals', () => {
+    const vo = PaymentAmount.create(10.123);
+    expect(vo.hasError).toBe(true);
+  });
+});

--- a/src/domain/aggregates/credit-card-bill/value-objects/payment-amount/PaymentAmount.ts
+++ b/src/domain/aggregates/credit-card-bill/value-objects/payment-amount/PaymentAmount.ts
@@ -1,0 +1,50 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { MoneyVo } from '../../../../shared/value-objects/money-vo/MoneyVo';
+import { InvalidPaymentAmountError } from '../../errors/InvalidPaymentAmountError';
+
+export type PaymentAmountValue = {
+  cents: number;
+};
+
+export class PaymentAmount implements IValueObject<PaymentAmountValue> {
+  private either = new Either<DomainError, PaymentAmountValue>();
+
+  private constructor(private readonly _amount: number) {
+    this.validate();
+  }
+
+  get value(): PaymentAmountValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return vo instanceof PaymentAmount && vo.value?.cents === this.value?.cents;
+  }
+
+  static create(amount: number): PaymentAmount {
+    return new PaymentAmount(amount);
+  }
+
+  private validate() {
+    const money = MoneyVo.create(this._amount);
+    if (money.hasError) this.either.addManyErrors(money.errors);
+
+    if (this._amount <= 0) this.either.addError(new InvalidPaymentAmountError());
+
+    if (Math.round(this._amount * 100) !== this._amount * 100)
+      this.either.addError(new InvalidPaymentAmountError());
+
+    if (!this.either.hasError) this.either.setData({ cents: money.value!.cents });
+  }
+}

--- a/src/domain/aggregates/credit-card-bill/value-objects/payment-date/PaymentDate.spec.ts
+++ b/src/domain/aggregates/credit-card-bill/value-objects/payment-date/PaymentDate.spec.ts
@@ -1,0 +1,22 @@
+import { PaymentDate } from './PaymentDate';
+
+describe('PaymentDate', () => {
+  it('should create a valid payment date', () => {
+    const date = new Date();
+    const vo = PaymentDate.create(date);
+    expect(vo.hasError).toBe(false);
+    expect(vo.value?.date).toEqual(date);
+  });
+
+  it('should return error for future date', () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 1);
+    const vo = PaymentDate.create(future);
+    expect(vo.hasError).toBe(true);
+  });
+
+  it('should return error for invalid date', () => {
+    const vo = PaymentDate.create(new Date('invalid'));
+    expect(vo.hasError).toBe(true);
+  });
+});

--- a/src/domain/aggregates/credit-card-bill/value-objects/payment-date/PaymentDate.ts
+++ b/src/domain/aggregates/credit-card-bill/value-objects/payment-date/PaymentDate.ts
@@ -1,0 +1,54 @@
+import { Either } from '@either';
+
+import { DomainError } from '../../../../shared/DomainError';
+import { IValueObject } from '../../../../shared/IValueObject';
+import { InvalidPaymentDateError } from '../../errors/InvalidPaymentDateError';
+
+export type PaymentDateValue = {
+  date: Date;
+};
+
+export class PaymentDate implements IValueObject<PaymentDateValue> {
+  private either = new Either<DomainError, PaymentDateValue>();
+
+  private constructor(private readonly _date: Date) {
+    this.validate();
+  }
+
+  get value(): PaymentDateValue | null {
+    return this.either.data ?? null;
+  }
+
+  get hasError(): boolean {
+    return this.either.hasError;
+  }
+
+  get errors(): DomainError[] {
+    return this.either.errors;
+  }
+
+  equals(vo: this): boolean {
+    return (
+      vo instanceof PaymentDate &&
+      vo.value?.date.getTime() === this.value?.date.getTime()
+    );
+  }
+
+  static create(date: Date): PaymentDate {
+    return new PaymentDate(date);
+  }
+
+  private validate() {
+    if (!(this._date instanceof Date) || isNaN(this._date.getTime())) {
+      this.either.addError(new InvalidPaymentDateError());
+      return;
+    }
+
+    const now = new Date();
+    if (this._date.getTime() > now.getTime()) {
+      this.either.addError(new InvalidPaymentDateError());
+    }
+
+    this.either.setData({ date: this._date });
+  }
+}


### PR DESCRIPTION
## Summary
- add PaymentAmount and PaymentDate value objects
- extend CreditCardBill to validate and mark bill as paid
- create PayCreditCardBill unit of work interface and stub
- implement MarkCreditCardBillAsPaid use case with tests
- document UC031 completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2a5924848323b4cc1c0bc377d87b