### PR TITLE
feat: add budget overview query handler

### DIFF
--- a/docs/query-view-planning.md
+++ b/docs/query-view-planning.md
@@ -242,7 +242,7 @@ Cada bloco define: _nome_, _campos_, _fonte_, _derivados_, _endpoint sugerido_.
 | Handler                      | Input                    | Output          | DAO(s)                                                  | Complexidade      |
 | ---------------------------- | ------------------------ | --------------- | ------------------------------------------------------- | ----------------- |
 | ListBudgetsQueryHandler      | userId                   | budgets[]       | BudgetsDao                                              | Baixa             |
-| BudgetOverviewQueryHandler   | budgetId,userId          | overview        | BudgetsDao + AccountsDao + TransactionsDao (sum mensal) | Média             |
+| BudgetOverviewQueryHandler (Implemented)   | budgetId,userId          | overview        | BudgetsDao + AccountsDao + TransactionsDao (sum mensal) | Média             |
 | ListAccountsQueryHandler     | budgetId,userId          | accounts[]      | AccountsDao                                             | Baixa             |
 | ListTransactionsQueryHandler | budgetId,userId, filtros | page transações | TransactionsDao                                         | Média (paginação) |
 | ListEnvelopesQueryHandler    | budgetId,userId          | envelopes[]     | EnvelopesDao                                            | Baixa             |

--- a/src/application/contracts/daos/budget/IGetBudgetOverviewDao.ts
+++ b/src/application/contracts/daos/budget/IGetBudgetOverviewDao.ts
@@ -1,0 +1,32 @@
+export interface BudgetCore {
+  id: string;
+  name: string;
+  type: 'PERSONAL' | 'SHARED';
+}
+
+export interface BudgetParticipant {
+  id: string;
+}
+
+export interface BudgetAccount {
+  id: string;
+  name: string;
+  type: string;
+  balance: number;
+}
+
+export interface MonthlyAggregates {
+  income: number;
+  expense: number;
+}
+
+export interface IGetBudgetOverviewDao {
+  fetchBudgetCore(budgetId: string, userId: string): Promise<BudgetCore | null>;
+  fetchParticipants(budgetId: string): Promise<BudgetParticipant[]>;
+  fetchAccounts(budgetId: string): Promise<BudgetAccount[]>;
+  fetchMonthlyAggregates(
+    budgetId: string,
+    periodStart: Date,
+    periodEnd: Date,
+  ): Promise<MonthlyAggregates>;
+}

--- a/src/application/queries/budget/budget-overview/BudgetOverviewQueryHandler.spec.ts
+++ b/src/application/queries/budget/budget-overview/BudgetOverviewQueryHandler.spec.ts
@@ -1,0 +1,67 @@
+import {
+  IGetBudgetOverviewDao,
+  BudgetAccount,
+  BudgetCore,
+  BudgetParticipant,
+  MonthlyAggregates,
+} from '@application/contracts/daos/budget/IGetBudgetOverviewDao';
+import { BudgetNotFoundError } from '@application/shared/errors/BudgetNotFoundError';
+import { BudgetOverviewQueryHandler } from './BudgetOverviewQueryHandler';
+
+describe('BudgetOverviewQueryHandler', () => {
+  class DaoStub implements IGetBudgetOverviewDao {
+    budget: BudgetCore | null = null;
+    participants: BudgetParticipant[] = [];
+    accounts: BudgetAccount[] = [];
+    aggregates: MonthlyAggregates = { income: 0, expense: 0 };
+    async fetchBudgetCore(): Promise<BudgetCore | null> {
+      return this.budget;
+    }
+    async fetchParticipants(): Promise<BudgetParticipant[]> {
+      return this.participants;
+    }
+    async fetchAccounts(): Promise<BudgetAccount[]> {
+      return this.accounts;
+    }
+    async fetchMonthlyAggregates(): Promise<MonthlyAggregates> {
+      return this.aggregates;
+    }
+  }
+
+  it('should throw not found when budget inaccessible', async () => {
+    const dao = new DaoStub();
+    dao.budget = null;
+    const handler = new BudgetOverviewQueryHandler(dao);
+    await expect(
+      handler.execute({ budgetId: 'b1', userId: 'u1' }),
+    ).rejects.toBeInstanceOf(BudgetNotFoundError);
+  });
+
+  it('should compute totals and map fields', async () => {
+    const dao = new DaoStub();
+    dao.budget = { id: 'b1', name: 'Main', type: 'PERSONAL' };
+    dao.participants = [{ id: 'u1' }, { id: 'u2' }];
+    dao.accounts = [
+      { id: 'a1', name: 'A', type: 'CHECKING', balance: 1000 },
+      { id: 'a2', name: 'B', type: 'SAVINGS', balance: 2000 },
+    ];
+    dao.aggregates = { income: 5000, expense: 3000 };
+
+    const handler = new BudgetOverviewQueryHandler(dao);
+    const result = await handler.execute({ budgetId: 'b1', userId: 'u1' });
+
+    expect(result).toEqual({
+      id: 'b1',
+      name: 'Main',
+      type: 'PERSONAL',
+      participants: [{ id: 'u1' }, { id: 'u2' }],
+      accounts: dao.accounts,
+      totals: {
+        accountsBalance: 3000,
+        monthIncome: 5000,
+        monthExpense: 3000,
+        netMonth: 2000,
+      },
+    });
+  });
+});

--- a/src/application/queries/budget/budget-overview/BudgetOverviewQueryHandler.ts
+++ b/src/application/queries/budget/budget-overview/BudgetOverviewQueryHandler.ts
@@ -1,0 +1,87 @@
+// [ ] DAO methods implemented
+// [ ] Handler passes all tests
+// [ ] Route registered
+// [ ] NotFound path covered
+// [ ] Derived totals correct
+// [ ] No other files changed
+
+import { IQueryHandler } from '../../shared/IQueryHandler';
+import { IGetBudgetOverviewDao } from '@application/contracts/daos/budget/IGetBudgetOverviewDao';
+import { BudgetNotFoundError } from '@application/shared/errors/BudgetNotFoundError';
+
+export interface BudgetOverviewQuery {
+  budgetId: string;
+  userId: string;
+}
+
+export interface BudgetOverviewQueryResult {
+  id: string;
+  name: string;
+  type: 'PERSONAL' | 'SHARED';
+  participants: { id: string }[];
+  totals: {
+    accountsBalance: number;
+    monthIncome: number;
+    monthExpense: number;
+    netMonth: number;
+  };
+  accounts: {
+    id: string;
+    name: string;
+    type: string;
+    balance: number;
+  }[];
+}
+
+export class BudgetOverviewQueryHandler
+  implements IQueryHandler<BudgetOverviewQuery, BudgetOverviewQueryResult>
+{
+  constructor(private readonly dao: IGetBudgetOverviewDao) {}
+
+  async execute(
+    query: BudgetOverviewQuery,
+  ): Promise<BudgetOverviewQueryResult> {
+    if (!query.budgetId || !query.userId) {
+      throw new Error('INVALID_QUERY');
+    }
+
+    const budgetCore = await this.dao.fetchBudgetCore(
+      query.budgetId,
+      query.userId,
+    );
+    if (!budgetCore) throw new BudgetNotFoundError();
+
+    const now = new Date();
+    const periodStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+    );
+    const periodEnd = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1),
+    );
+
+    const [participants, accounts, aggregates] = await Promise.all([
+      this.dao.fetchParticipants(query.budgetId),
+      this.dao.fetchAccounts(query.budgetId),
+      this.dao.fetchMonthlyAggregates(query.budgetId, periodStart, periodEnd),
+    ]);
+
+    const accountsBalance = accounts.reduce((sum, acc) => sum + acc.balance, 0);
+    const monthIncome = aggregates.income;
+    const monthExpense = aggregates.expense;
+    const netMonth = monthIncome - monthExpense;
+
+    return {
+      id: budgetCore.id,
+      name: budgetCore.name,
+      type: budgetCore.type,
+      participants,
+      accounts,
+      totals: {
+        accountsBalance,
+        monthIncome,
+        monthExpense,
+        netMonth,
+      },
+    };
+  }
+}

--- a/src/infrastructure/database/pg/daos/budget/budget-overview/BudgetOverviewDao.spec.ts
+++ b/src/infrastructure/database/pg/daos/budget/budget-overview/BudgetOverviewDao.spec.ts
@@ -1,0 +1,54 @@
+import { IPostgresConnectionAdapter } from '@infrastructure/adapters/IPostgresConnectionAdapter';
+import { BudgetOverviewDao } from './BudgetOverviewDao';
+
+describe('BudgetOverviewDao', () => {
+  let dao: BudgetOverviewDao;
+  let mockConnection: jest.Mocked<IPostgresConnectionAdapter>;
+
+  beforeEach(() => {
+    mockConnection = {
+      query: jest.fn(),
+      transaction: jest.fn(),
+      getClient: jest.fn(),
+    } as unknown as jest.Mocked<IPostgresConnectionAdapter>;
+    dao = new BudgetOverviewDao(mockConnection);
+  });
+
+  it('should map monthly aggregates', async () => {
+    mockConnection.query.mockResolvedValue({
+      rows: [{ income: '5000', expense: '2000' }],
+      rowCount: 1,
+    });
+    const result = await dao.fetchMonthlyAggregates(
+      'b1',
+      new Date('2024-01-01'),
+      new Date('2024-02-01'),
+    );
+    expect(result).toEqual({ income: 5000, expense: 2000 });
+  });
+
+  it('should return zeros when no transactions', async () => {
+    mockConnection.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    const result = await dao.fetchMonthlyAggregates(
+      'b1',
+      new Date('2024-01-01'),
+      new Date('2024-02-01'),
+    );
+    expect(result).toEqual({ income: 0, expense: 0 });
+  });
+
+  it('should return null when user has no access', async () => {
+    mockConnection.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    const result = await dao.fetchBudgetCore('b1', 'u1');
+    expect(result).toBeNull();
+  });
+
+  it('should deduplicate participants', async () => {
+    mockConnection.query.mockResolvedValue({
+      rows: [{ owner_id: 'u1', participant_ids: ['u1', 'u2'] }],
+      rowCount: 1,
+    });
+    const result = await dao.fetchParticipants('b1');
+    expect(result).toEqual([{ id: 'u1' }, { id: 'u2' }]);
+  });
+});

--- a/src/infrastructure/database/pg/daos/budget/budget-overview/BudgetOverviewDao.ts
+++ b/src/infrastructure/database/pg/daos/budget/budget-overview/BudgetOverviewDao.ts
@@ -1,0 +1,97 @@
+import {
+  BudgetAccount,
+  BudgetCore,
+  BudgetParticipant,
+  IGetBudgetOverviewDao,
+  MonthlyAggregates,
+} from '@application/contracts/daos/budget/IGetBudgetOverviewDao';
+import { IPostgresConnectionAdapter } from '@infrastructure/adapters/IPostgresConnectionAdapter';
+
+export class BudgetOverviewDao implements IGetBudgetOverviewDao {
+  constructor(private readonly connection: IPostgresConnectionAdapter) {}
+
+  async fetchBudgetCore(
+    budgetId: string,
+    userId: string,
+  ): Promise<BudgetCore | null> {
+    const result = await this.connection.query<BudgetCore>(
+      `SELECT id, name, type
+       FROM budgets
+       WHERE id = $1 AND is_deleted = false
+         AND (owner_id = $2 OR $2 = ANY(participant_ids))`,
+      [budgetId, userId],
+    );
+
+    if (!result || result.rowCount === 0) return null;
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      name: row.name,
+      type: row.type as 'PERSONAL' | 'SHARED',
+    };
+  }
+
+  async fetchParticipants(budgetId: string): Promise<BudgetParticipant[]> {
+    const result = await this.connection.query<{
+      owner_id: string;
+      participant_ids: string[];
+    }>(`SELECT owner_id, participant_ids FROM budgets WHERE id = $1`, [
+      budgetId,
+    ]);
+
+    if (!result || result.rowCount === 0) return [];
+    const row = result.rows[0];
+    const set = new Set<string>();
+    if (row.owner_id) set.add(row.owner_id);
+    if (row.participant_ids) {
+      for (const p of row.participant_ids) set.add(p);
+    }
+    return Array.from(set).map((id) => ({ id }));
+  }
+
+  async fetchAccounts(budgetId: string): Promise<BudgetAccount[]> {
+    const result = await this.connection.query<
+      BudgetAccount & { balance: string }
+    >(
+      `SELECT id, name, type, balance
+       FROM accounts
+       WHERE budget_id = $1 AND is_deleted = false`,
+      [budgetId],
+    );
+
+    return (
+      result?.rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        type: row.type,
+        balance: Number(row.balance),
+      })) || []
+    );
+  }
+
+  async fetchMonthlyAggregates(
+    budgetId: string,
+    periodStart: Date,
+    periodEnd: Date,
+  ): Promise<MonthlyAggregates> {
+    const result = await this.connection.query<{
+      income: string | null;
+      expense: string | null;
+    }>(
+      `SELECT
+         COALESCE(SUM(CASE WHEN type = 'INCOME' THEN amount ELSE 0 END),0) AS income,
+         COALESCE(SUM(CASE WHEN type = 'EXPENSE' THEN amount ELSE 0 END),0) AS expense
+       FROM transactions
+       WHERE budget_id = $1
+         AND is_deleted = false
+         AND transaction_date >= $2 AND transaction_date < $3`,
+      [budgetId, periodStart, periodEnd],
+    );
+
+    const row = result?.rows[0];
+    return {
+      income: row ? Number(row.income) : 0,
+      expense: row ? Number(row.expense) : 0,
+    };
+  }
+}

--- a/src/main/routes/query-route-registry.ts
+++ b/src/main/routes/query-route-registry.ts
@@ -1,46 +1,18 @@
 // Registry de rotas de queries (views/read)
 import { ExpressHttpServerAdapter } from '@http/adapters/express-adapter';
-import { RouteDefinition } from '@http/server-adapter';
-import { BudgetOverviewQueryHandler } from '@application/queries/budget/budget-overview/BudgetOverviewQueryHandler';
-import { BudgetOverviewDao } from '@infrastructure/database/pg/daos/budget/budget-overview/BudgetOverviewDao';
-import { PostgresConnectionAdapter } from '../../adapters/postgres/PostgresConnectionAdapter';
-import { loadEnv } from '../../config/env';
-
-const env = loadEnv();
-const pgConnection = new PostgresConnectionAdapter({
-  host: env.DB_HOST,
-  port: Number(env.DB_PORT),
-  database: env.DB_NAME,
-  user: env.DB_USER,
-  password: env.DB_PASSWORD,
-});
 
 // Dependências a serem injetadas (DAOs, serviços, etc.)
 export interface QueryRegistryDeps {
   server: ExpressHttpServerAdapter;
+  // Exemplo: listBudgetsDao: IListBudgetsDao
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function registerQueryRoutes(deps: QueryRegistryDeps) {
-  const { server } = deps;
-  const handler = new BudgetOverviewQueryHandler(
-    new BudgetOverviewDao(pgConnection),
-  );
-
-  const routes: RouteDefinition[] = [
-    {
-      method: 'GET',
-      path: '/budget/:budgetId/overview',
-      controller: {
-        handle: async (req) => {
-          const result = await handler.execute({
-            budgetId: req.params.budgetId,
-            userId: req.principal?.userId || '',
-          });
-          return { status: 200, body: { data: result } };
-        },
-      },
-    },
-  ];
-
-  server.registerRoutes(routes);
+  // const { server } = deps;
+  // const app = server.rawApp;
+  // Exemplo de uso futuro:
+  // app.get('/budgets', async (req, res) => { ... });
+  // app.get('/accounts', ...)
+  // Por ora, apenas placeholder
 }

--- a/src/main/routes/query-route-registry.ts
+++ b/src/main/routes/query-route-registry.ts
@@ -1,18 +1,46 @@
 // Registry de rotas de queries (views/read)
 import { ExpressHttpServerAdapter } from '@http/adapters/express-adapter';
+import { RouteDefinition } from '@http/server-adapter';
+import { BudgetOverviewQueryHandler } from '@application/queries/budget/budget-overview/BudgetOverviewQueryHandler';
+import { BudgetOverviewDao } from '@infrastructure/database/pg/daos/budget/budget-overview/BudgetOverviewDao';
+import { PostgresConnectionAdapter } from '../../adapters/postgres/PostgresConnectionAdapter';
+import { loadEnv } from '../../config/env';
+
+const env = loadEnv();
+const pgConnection = new PostgresConnectionAdapter({
+  host: env.DB_HOST,
+  port: Number(env.DB_PORT),
+  database: env.DB_NAME,
+  user: env.DB_USER,
+  password: env.DB_PASSWORD,
+});
 
 // Dependências a serem injetadas (DAOs, serviços, etc.)
 export interface QueryRegistryDeps {
   server: ExpressHttpServerAdapter;
-  // Exemplo: listBudgetsDao: IListBudgetsDao
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function registerQueryRoutes(deps: QueryRegistryDeps) {
-  // const { server } = deps;
-  // const app = server.rawApp;
-  // Exemplo de uso futuro:
-  // app.get('/budgets', async (req, res) => { ... });
-  // app.get('/accounts', ...)
-  // Por ora, apenas placeholder
+  const { server } = deps;
+  const handler = new BudgetOverviewQueryHandler(
+    new BudgetOverviewDao(pgConnection),
+  );
+
+  const routes: RouteDefinition[] = [
+    {
+      method: 'GET',
+      path: '/budget/:budgetId/overview',
+      controller: {
+        handle: async (req) => {
+          const result = await handler.execute({
+            budgetId: req.params.budgetId,
+            userId: req.principal?.userId || '',
+          });
+          return { status: 200, body: { data: result } };
+        },
+      },
+    },
+  ];
+
+  server.registerRoutes(routes);
 }


### PR DESCRIPTION
## Summary
- implement budget overview query handler and DAO
- expose GET /budget/:budgetId/overview
- document handler as implemented

## Testing
- `npm test -- src/tests/integration/credit-card-composition-root.test.ts` *(fails: Could not find a working container runtime strategy)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a753b78594832382d2365bebbc636b