### PR TITLE
feat: add list goals query handler

### DIFF
--- a/docs/query-view-planning.md
+++ b/docs/query-view-planning.md
@@ -246,7 +246,7 @@ Cada bloco define: _nome_, _campos_, _fonte_, _derivados_, _endpoint sugerido_.
 | ListAccountsQueryHandler     | budgetId,userId          | accounts[]      | AccountsDao                                             | Baixa             |
 | ListTransactionsQueryHandler | budgetId,userId, filtros | page transações | TransactionsDao                                         | Média (paginação) |
 | ListEnvelopesQueryHandler    | budgetId,userId          | envelopes[]     | EnvelopesDao                                            | Baixa             |
-| ListGoalsQueryHandler        | budgetId,userId          | goals[]         | GoalsDao                                                | Baixa             |
+| ListGoalsQueryHandler (Implemented)        | budgetId,userId          | goals[]         | GoalsDao                                                | Baixa             |
 | ListCategoriesQueryHandler   | (userId opcional)        | categorias[]    | CategoriesDao                                           | Baixa             |
 
 ## 6. Métricas & Observabilidade

--- a/src/application/contracts/daos/goal/IListGoalsDao.ts
+++ b/src/application/contracts/daos/goal/IListGoalsDao.ts
@@ -1,0 +1,14 @@
+export interface GoalListItem {
+  id: string;
+  name: string;
+  targetAmount: number;
+  currentAmount: number;
+  dueDate: string | null;
+}
+
+export interface IListGoalsDao {
+  findByBudgetForUser(
+    budgetId: string,
+    userId: string,
+  ): Promise<GoalListItem[] | null>;
+}

--- a/src/application/queries/budget/list-goals/ListGoalsQueryHandler.spec.ts
+++ b/src/application/queries/budget/list-goals/ListGoalsQueryHandler.spec.ts
@@ -1,0 +1,116 @@
+import {
+  GoalListItem,
+  IListGoalsDao,
+} from '@application/contracts/daos/goal/IListGoalsDao';
+
+import {
+  ListGoalsQueryHandler,
+  ListGoalsQuery,
+  ListGoalsQueryResult,
+} from './ListGoalsQueryHandler';
+
+describe('ListGoalsQueryHandler', () => {
+  class ListGoalsDaoStub implements IListGoalsDao {
+    public result: GoalListItem[] | null = [];
+    async findByBudgetForUser(
+      budgetId: string,
+      userId: string,
+    ): Promise<GoalListItem[] | null> {
+      return this.result;
+    }
+  }
+
+  let dao: ListGoalsDaoStub;
+  let handler: ListGoalsQueryHandler;
+
+  beforeEach(() => {
+    dao = new ListGoalsDaoStub();
+    handler = new ListGoalsQueryHandler(dao);
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-10'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const query: ListGoalsQuery = { budgetId: 'b1', userId: 'u1' };
+
+  it('should throw NOT_FOUND when dao returns null', async () => {
+    dao.result = null;
+    await expect(handler.execute(query)).rejects.toThrow('NOT_FOUND');
+  });
+
+  it('should return empty array when dao returns empty array', async () => {
+    dao.result = [];
+    const result = await handler.execute(query);
+    expect(result).toEqual([]);
+  });
+
+  it('should calculate percentAchieved and status correctly', async () => {
+    dao.result = [
+      { id: '1', name: 'g1', targetAmount: 0, currentAmount: 100, dueDate: null },
+      {
+        id: '2',
+        name: 'g2',
+        targetAmount: 1000,
+        currentAmount: 1000,
+        dueDate: '2024-01-05',
+      },
+      {
+        id: '3',
+        name: 'g3',
+        targetAmount: 1000,
+        currentAmount: 200,
+        dueDate: '2024-01-01',
+      },
+      {
+        id: '4',
+        name: 'g4',
+        targetAmount: 1000,
+        currentAmount: 200,
+        dueDate: '2024-02-01',
+      },
+    ];
+
+    const result: ListGoalsQueryResult = await handler.execute(query);
+
+    expect(result).toEqual([
+      {
+        id: '1',
+        name: 'g1',
+        targetAmount: 0,
+        currentAmount: 100,
+        percentAchieved: 0,
+        dueDate: null,
+        status: 'ACTIVE',
+      },
+      {
+        id: '2',
+        name: 'g2',
+        targetAmount: 1000,
+        currentAmount: 1000,
+        percentAchieved: 1,
+        dueDate: '2024-01-05',
+        status: 'ACHIEVED',
+      },
+      {
+        id: '3',
+        name: 'g3',
+        targetAmount: 1000,
+        currentAmount: 200,
+        percentAchieved: 0.2,
+        dueDate: '2024-01-01',
+        status: 'OVERDUE',
+      },
+      {
+        id: '4',
+        name: 'g4',
+        targetAmount: 1000,
+        currentAmount: 200,
+        percentAchieved: 0.2,
+        dueDate: '2024-02-01',
+        status: 'ACTIVE',
+      },
+    ]);
+  });
+});

--- a/src/application/queries/budget/list-goals/ListGoalsQueryHandler.ts
+++ b/src/application/queries/budget/list-goals/ListGoalsQueryHandler.ts
@@ -1,0 +1,74 @@
+/*
+ * Acceptance Checklist
+ * [ ] DAO interface created
+ * [ ] DAO implemented with auth check + listing
+ * [ ] Handler validates input and adapts output (percentAchieved, status)
+ * [ ] Specs passing (DAO + Handler)
+ * [ ] docs/query-view-planning.md updated row
+ * [ ] No other files changed
+ * [ ] Route NOT registered
+ */
+import {
+  GoalListItem,
+  IListGoalsDao,
+} from '@application/contracts/daos/goal/IListGoalsDao';
+import { IQueryHandler } from '../../shared/IQueryHandler';
+
+export interface ListGoalsQuery {
+  budgetId: string;
+  userId: string;
+}
+
+export type GoalStatus = 'ACTIVE' | 'ACHIEVED' | 'OVERDUE';
+
+export interface ListGoalsItem {
+  id: string;
+  name: string;
+  targetAmount: number;
+  currentAmount: number;
+  percentAchieved: number;
+  dueDate: string | null;
+  status: GoalStatus;
+}
+
+export type ListGoalsQueryResult = ListGoalsItem[];
+
+export class ListGoalsQueryHandler
+  implements IQueryHandler<ListGoalsQuery, ListGoalsQueryResult>
+{
+  constructor(private readonly listGoalsDao: IListGoalsDao) {}
+
+  async execute(query: ListGoalsQuery): Promise<ListGoalsQueryResult> {
+    const { budgetId, userId } = query;
+    if (!budgetId || !userId) {
+      throw new Error('INVALID_INPUT');
+    }
+
+    const items = await this.listGoalsDao.findByBudgetForUser(budgetId, userId);
+    if (items === null) {
+      throw new Error('NOT_FOUND');
+    }
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    return items.map((i: GoalListItem) => {
+      const percent = i.targetAmount === 0 ? 0 : i.currentAmount / i.targetAmount;
+      let status: GoalStatus = 'ACTIVE';
+      if (i.targetAmount > 0 && i.currentAmount >= i.targetAmount) {
+        status = 'ACHIEVED';
+      } else if (i.dueDate && today > i.dueDate) {
+        status = 'OVERDUE';
+      }
+
+      return {
+        id: i.id,
+        name: i.name,
+        targetAmount: i.targetAmount,
+        currentAmount: i.currentAmount,
+        percentAchieved: percent,
+        dueDate: i.dueDate,
+        status,
+      };
+    });
+  }
+}

--- a/src/infrastructure/database/pg/daos/goal/list-goals/ListGoalsDao.spec.ts
+++ b/src/infrastructure/database/pg/daos/goal/list-goals/ListGoalsDao.spec.ts
@@ -1,0 +1,72 @@
+import { IPostgresConnectionAdapter } from '@infrastructure/adapters/IPostgresConnectionAdapter';
+
+import { ListGoalsDao } from './ListGoalsDao';
+
+describe('ListGoalsDao', () => {
+  let dao: ListGoalsDao;
+  let mockConnection: jest.Mocked<IPostgresConnectionAdapter>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const mockClient = {
+      query: jest.fn(),
+      release: jest.fn(),
+    };
+
+    mockConnection = {
+      query: jest.fn(),
+      transaction: jest.fn(),
+      getClient: jest.fn().mockResolvedValue(mockClient),
+    } as unknown as jest.Mocked<IPostgresConnectionAdapter>;
+
+    dao = new ListGoalsDao(mockConnection);
+  });
+
+  it('should return null when user is not authorized', async () => {
+    mockConnection.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return empty array when no goals are found', async () => {
+    mockConnection.query
+      .mockResolvedValueOnce({ rows: [{}], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('should map rows correctly', async () => {
+    mockConnection.query
+      .mockResolvedValueOnce({ rows: [{}], rowCount: 1 })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'g1',
+            name: 'Goal 1',
+            total_amount: 1000,
+            accumulated_amount: 200,
+            due_date: '2024-12-31',
+          },
+        ],
+        rowCount: 1,
+      });
+
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+
+    expect(result).toEqual([
+      {
+        id: 'g1',
+        name: 'Goal 1',
+        targetAmount: 1000,
+        currentAmount: 200,
+        dueDate: '2024-12-31',
+      },
+    ]);
+  });
+});

--- a/src/infrastructure/database/pg/daos/goal/list-goals/ListGoalsDao.ts
+++ b/src/infrastructure/database/pg/daos/goal/list-goals/ListGoalsDao.ts
@@ -1,0 +1,56 @@
+import {
+  GoalListItem,
+  IListGoalsDao,
+} from '@application/contracts/daos/goal/IListGoalsDao';
+import { IPostgresConnectionAdapter } from '../../../../../adapters/IPostgresConnectionAdapter';
+
+export class ListGoalsDao implements IListGoalsDao {
+  constructor(private readonly connection: IPostgresConnectionAdapter) {}
+
+  async findByBudgetForUser(
+    budgetId: string,
+    userId: string,
+  ): Promise<GoalListItem[] | null> {
+    const auth = await this.connection.query(
+      `SELECT 1
+         FROM budgets
+        WHERE id = $1
+          AND is_deleted = false
+          AND (owner_id = $2 OR $2 = ANY(participant_ids))`,
+      [budgetId, userId],
+    );
+
+    if (!auth?.rowCount) {
+      return null;
+    }
+
+    const result = await this.connection.query<{
+      id: string;
+      name: string;
+      total_amount: number | string;
+      accumulated_amount: number | string;
+      due_date: string | null;
+    }>(
+      `SELECT id,
+              name,
+              total_amount,
+              accumulated_amount,
+              deadline::date AS due_date
+         FROM goals
+        WHERE budget_id = $1
+          AND is_deleted = false
+        ORDER BY due_date NULLS LAST, name ASC`,
+      [budgetId],
+    );
+
+    return (
+      result?.rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        targetAmount: Number(row.total_amount),
+        currentAmount: Number(row.accumulated_amount),
+        dueDate: row.due_date,
+      })) || []
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add DAO contract and implementation for listing goals
- implement ListGoalsQueryHandler with percent and status logic
- document ListGoalsQueryHandler as implemented

## Testing
- `npm test` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68a76beba8b48323bead0da6d6d8a25a