### PR TITLE
feat: add list envelopes query handler and dao

### DIFF
--- a/docs/query-view-planning.md
+++ b/docs/query-view-planning.md
@@ -245,7 +245,7 @@ Cada bloco define: _nome_, _campos_, _fonte_, _derivados_, _endpoint sugerido_.
 | BudgetOverviewQueryHandler   | budgetId,userId          | overview        | BudgetsDao + AccountsDao + TransactionsDao (sum mensal) | Média             |
 | ListAccountsQueryHandler     | budgetId,userId          | accounts[]      | AccountsDao                                             | Baixa             |
 | ListTransactionsQueryHandler | budgetId,userId, filtros | page transações | TransactionsDao                                         | Média (paginação) |
-| ListEnvelopesQueryHandler    | budgetId,userId          | envelopes[]     | EnvelopesDao                                            | Baixa             |
+| ListEnvelopesQueryHandler | budgetId,userId | envelopes[] | EnvelopesDao | Baixa (Implemented) |
 | ListGoalsQueryHandler        | budgetId,userId          | goals[]         | GoalsDao                                                | Baixa             |
 | ListCategoriesQueryHandler   | (userId opcional)        | categorias[]    | CategoriesDao                                           | Baixa             |
 

--- a/src/application/contracts/daos/envelope/IListEnvelopesDao.ts
+++ b/src/application/contracts/daos/envelope/IListEnvelopesDao.ts
@@ -1,0 +1,13 @@
+export interface EnvelopeListItem {
+  id: string;
+  name: string;
+  allocated: number;
+  spent: number;
+}
+
+export interface IListEnvelopesDao {
+  findByBudgetForUser(
+    budgetId: string,
+    userId: string,
+  ): Promise<EnvelopeListItem[] | null>;
+}

--- a/src/application/queries/budget/list-envelopes/ListEnvelopesQueryHandler.spec.ts
+++ b/src/application/queries/budget/list-envelopes/ListEnvelopesQueryHandler.spec.ts
@@ -1,0 +1,54 @@
+import { ListEnvelopesQueryHandler } from '@application/queries/budget/list-envelopes/ListEnvelopesQueryHandler';
+import { IListEnvelopesDao } from '@application/contracts/daos/envelope/IListEnvelopesDao';
+import { BudgetNotFoundError } from '@application/shared/errors/BudgetNotFoundError';
+
+describe('ListEnvelopesQueryHandler', () => {
+  let dao: jest.Mocked<IListEnvelopesDao>;
+  let handler: ListEnvelopesQueryHandler;
+
+  beforeEach(() => {
+    dao = {
+      findByBudgetForUser: jest.fn(),
+    };
+    handler = new ListEnvelopesQueryHandler(dao);
+  });
+
+  it('should throw when dao returns null', async () => {
+    dao.findByBudgetForUser.mockResolvedValue(null);
+    await expect(
+      handler.execute({ budgetId: 'b1', userId: 'u1' }),
+    ).rejects.toBeInstanceOf(BudgetNotFoundError);
+  });
+
+  it('should return empty array when dao returns empty', async () => {
+    dao.findByBudgetForUser.mockResolvedValue([]);
+    const result = await handler.execute({ budgetId: 'b1', userId: 'u1' });
+    expect(result).toEqual([]);
+  });
+
+  it('should map items with remaining and percentUsed', async () => {
+    dao.findByBudgetForUser.mockResolvedValue([
+      { id: 'e1', name: 'Food', allocated: 10000, spent: 2500 },
+      { id: 'e2', name: 'Zero', allocated: 0, spent: 1000 },
+    ]);
+    const result = await handler.execute({ budgetId: 'b1', userId: 'u1' });
+    expect(result).toEqual([
+      {
+        id: 'e1',
+        name: 'Food',
+        allocated: 10000,
+        spent: 2500,
+        remaining: 7500,
+        percentUsed: 0.25,
+      },
+      {
+        id: 'e2',
+        name: 'Zero',
+        allocated: 0,
+        spent: 1000,
+        remaining: -1000,
+        percentUsed: 0,
+      },
+    ]);
+  });
+});

--- a/src/application/queries/budget/list-envelopes/ListEnvelopesQueryHandler.ts
+++ b/src/application/queries/budget/list-envelopes/ListEnvelopesQueryHandler.ts
@@ -1,0 +1,64 @@
+/**
+ * Acceptance Criteria
+ * - [ ] DAO interface created
+ * - [ ] DAO implemented with auth check + listing + spent aggregate
+ * - [ ] Handler validates input and adapts output (remaining, percentUsed)
+ * - [ ] Specs passing (DAO + Handler)
+ * - [ ] docs/query-view-planning.md updated row
+ * - [ ] No other files changed
+ * - [ ] Route NOT registered
+ */
+
+import { BudgetNotFoundError } from '@application/shared/errors/BudgetNotFoundError';
+import { IListEnvelopesDao } from '../../../contracts/daos/envelope/IListEnvelopesDao';
+import { IQueryHandler } from '../../shared/IQueryHandler';
+
+export interface ListEnvelopesQuery {
+  budgetId: string;
+  userId: string;
+}
+
+export interface ListEnvelopesItem {
+  id: string;
+  name: string;
+  allocated: number;
+  spent: number;
+  remaining: number;
+  percentUsed: number;
+}
+
+export type ListEnvelopesQueryResult = ListEnvelopesItem[];
+
+export class ListEnvelopesQueryHandler
+  implements IQueryHandler<ListEnvelopesQuery, ListEnvelopesQueryResult>
+{
+  constructor(private readonly listEnvelopesDao: IListEnvelopesDao) {}
+
+  async execute(query: ListEnvelopesQuery): Promise<ListEnvelopesQueryResult> {
+    if (!query.budgetId || !query.userId) {
+      throw new Error('INVALID_INPUT');
+    }
+
+    const items = await this.listEnvelopesDao.findByBudgetForUser(
+      query.budgetId,
+      query.userId,
+    );
+
+    if (items === null) {
+      throw new BudgetNotFoundError();
+    }
+
+    return items.map((item) => {
+      const remaining = item.allocated - item.spent;
+      const percentUsed = item.allocated === 0 ? 0 : item.spent / item.allocated;
+      return {
+        id: item.id,
+        name: item.name,
+        allocated: item.allocated,
+        spent: item.spent,
+        remaining,
+        percentUsed,
+      };
+    });
+  }
+}

--- a/src/infrastructure/database/pg/daos/envelope/list-envelopes/ListEnvelopesDao.spec.ts
+++ b/src/infrastructure/database/pg/daos/envelope/list-envelopes/ListEnvelopesDao.spec.ts
@@ -1,0 +1,64 @@
+import { IPostgresConnectionAdapter } from '@infrastructure/adapters/IPostgresConnectionAdapter';
+import { ListEnvelopesDao } from './ListEnvelopesDao';
+
+describe('ListEnvelopesDao', () => {
+  let dao: ListEnvelopesDao;
+  let mockConnection: jest.Mocked<IPostgresConnectionAdapter>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const mockClient = {
+      query: jest.fn(),
+      release: jest.fn(),
+    };
+    mockConnection = {
+      query: jest.fn(),
+      transaction: jest.fn(),
+      getClient: jest.fn().mockResolvedValue(mockClient),
+    } as unknown as jest.Mocked<IPostgresConnectionAdapter>;
+    dao = new ListEnvelopesDao(mockConnection);
+  });
+
+  it('should return null when user unauthorized', async () => {
+    mockConnection.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+    expect(result).toBeNull();
+    expect(mockConnection.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return empty array when no envelopes', async () => {
+    mockConnection.query
+      .mockResolvedValueOnce({ rows: [{ exists: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+    expect(result).toEqual([]);
+    expect(mockConnection.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('should map rows correctly', async () => {
+    mockConnection.query
+      .mockResolvedValueOnce({ rows: [{ exists: 1 }], rowCount: 1 })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'e1',
+            name: 'Food',
+            allocated_cents: '1000',
+            spent_cents: '300',
+          },
+          {
+            id: 'e2',
+            name: 'Rent',
+            allocated_cents: '2000',
+            spent_cents: null,
+          },
+        ],
+        rowCount: 2,
+      });
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+    expect(result).toEqual([
+      { id: 'e1', name: 'Food', allocated: 1000, spent: 300 },
+      { id: 'e2', name: 'Rent', allocated: 2000, spent: 0 },
+    ]);
+  });
+});

--- a/src/infrastructure/database/pg/daos/envelope/list-envelopes/ListEnvelopesDao.ts
+++ b/src/infrastructure/database/pg/daos/envelope/list-envelopes/ListEnvelopesDao.ts
@@ -1,0 +1,53 @@
+import {
+  EnvelopeListItem,
+  IListEnvelopesDao,
+} from '@application/contracts/daos/envelope/IListEnvelopesDao';
+import { IPostgresConnectionAdapter } from '../../../../../adapters/IPostgresConnectionAdapter';
+
+export class ListEnvelopesDao implements IListEnvelopesDao {
+  constructor(private readonly connection: IPostgresConnectionAdapter) {}
+
+  async findByBudgetForUser(
+    budgetId: string,
+    userId: string,
+  ): Promise<EnvelopeListItem[] | null> {
+    const auth = await this.connection.query(
+      `SELECT 1 FROM budgets WHERE id = $1 AND (owner_id = $2 OR $2 = ANY(participant_ids))`,
+      [budgetId, userId],
+    );
+
+    if (!auth || auth.rowCount === 0) {
+      return null;
+    }
+
+    const result = await this.connection.query<{
+      id: string;
+      name: string;
+      allocated_cents: string;
+      spent_cents: string | null;
+    }>(
+      `SELECT e.id,
+              e.name,
+              e.allocated_cents,
+              COALESCE(SUM(CASE WHEN t.direction = 'OUT' THEN ABS(t.amount_cents) ELSE 0 END), 0) AS spent_cents
+         FROM envelopes e
+         LEFT JOIN transactions t
+           ON t.envelope_id = e.id
+          AND t.budget_id = e.budget_id
+          AND t.direction = 'OUT'
+        WHERE e.budget_id = $1
+        GROUP BY e.id, e.name, e.allocated_cents
+        ORDER BY e.name ASC`,
+      [budgetId],
+    );
+
+    return (
+      result?.rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        allocated: Number(row.allocated_cents),
+        spent: Number(row.spent_cents || 0),
+      })) || []
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add DAO and query handler to list envelopes of a budget
- cover edge cases with specs
- update docs to mark ListEnvelopesQueryHandler implemented

## Testing
- `npm test src/application/queries/budget/list-envelopes/ListEnvelopesQueryHandler.spec.ts src/infrastructure/database/pg/daos/envelope/list-envelopes/ListEnvelopesDao.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a76afbaac0832398d6d850c42b0db9