### PR TITLE
feat: add list accounts query handler

### DIFF
--- a/docs/query-view-planning.md
+++ b/docs/query-view-planning.md
@@ -239,15 +239,15 @@ Cada bloco define: _nome_, _campos_, _fonte_, _derivados_, _endpoint sugerido_.
 
 ## 5. QueryHandlers Planejados
 
-| Handler                      | Input                    | Output          | DAO(s)                                                  | Complexidade      |
-| ---------------------------- | ------------------------ | --------------- | ------------------------------------------------------- | ----------------- |
-| ListBudgetsQueryHandler      | userId                   | budgets[]       | BudgetsDao                                              | Baixa             |
+| Handler                      | Input                    | Output          | DAO(s)           | Complexidade      |
+| ---------------------------- | ------------------------ | --------------- | ---------------- | ----------------- |
+| ListBudgetsQueryHandler      | userId                   | budgets[]       | BudgetsDao       | Baixa             |
 | BudgetOverviewQueryHandler   | budgetId,userId          | overview        | BudgetsDao + AccountsDao + TransactionsDao (sum mensal) | Média             |
-| ListAccountsQueryHandler     | budgetId,userId          | accounts[]      | AccountsDao                                             | Baixa             |
-| ListTransactionsQueryHandler | budgetId,userId, filtros | page transações | TransactionsDao                                         | Média (paginação) |
-| ListEnvelopesQueryHandler    | budgetId,userId          | envelopes[]     | EnvelopesDao                                            | Baixa             |
-| ListGoalsQueryHandler        | budgetId,userId          | goals[]         | GoalsDao                                                | Baixa             |
-| ListCategoriesQueryHandler   | (userId opcional)        | categorias[]    | CategoriesDao                                           | Baixa             |
+| ListAccountsQueryHandler     | budgetId,userId          | accounts[]      | AccountsDao      | Baixa - Implemented |
+| ListTransactionsQueryHandler | budgetId,userId, filtros | page transações | TransactionsDao  | Média (paginação) |
+| ListEnvelopesQueryHandler    | budgetId,userId          | envelopes[]     | EnvelopesDao     | Baixa             |
+| ListGoalsQueryHandler        | budgetId,userId          | goals[]         | GoalsDao         | Baixa             |
+| ListCategoriesQueryHandler   | (userId opcional)        | categorias[]    | CategoriesDao    | Baixa             |
 
 ## 6. Métricas & Observabilidade
 

--- a/src/application/contracts/daos/account/IListAccountsDao.ts
+++ b/src/application/contracts/daos/account/IListAccountsDao.ts
@@ -1,0 +1,13 @@
+export interface ListAccountsItem {
+  id: string;
+  name: string;
+  type: string;
+  balance: number;
+}
+
+export interface IListAccountsDao {
+  findByBudgetForUser(
+    budgetId: string,
+    userId: string,
+  ): Promise<ListAccountsItem[] | null>;
+}

--- a/src/application/queries/budget/list-accounts/ListAccountsQueryHandler.spec.ts
+++ b/src/application/queries/budget/list-accounts/ListAccountsQueryHandler.spec.ts
@@ -1,0 +1,54 @@
+import {
+  IListAccountsDao,
+  ListAccountsItem,
+} from '@application/contracts/daos/account/IListAccountsDao';
+import { ListAccountsQueryHandler } from './ListAccountsQueryHandler';
+
+class ListAccountsDaoStub implements IListAccountsDao {
+  public items: ListAccountsItem[] | null = [];
+
+  async findByBudgetForUser(
+    budgetId: string,
+    userId: string,
+  ): Promise<ListAccountsItem[] | null> {
+    if (budgetId && userId) {
+      // noop
+    }
+    return this.items;
+  }
+}
+
+describe('ListAccountsQueryHandler', () => {
+  let dao: ListAccountsDaoStub;
+  let handler: ListAccountsQueryHandler;
+
+  beforeEach(() => {
+    dao = new ListAccountsDaoStub();
+    handler = new ListAccountsQueryHandler(dao);
+  });
+
+  it('should throw when dao returns null', async () => {
+    dao.items = null;
+    await expect(
+      handler.execute({ budgetId: 'b1', userId: 'u1' }),
+    ).rejects.toThrow('NOT_FOUND');
+  });
+
+  it('should return empty array when dao returns []', async () => {
+    dao.items = [];
+    const result = await handler.execute({ budgetId: 'b1', userId: 'u1' });
+    expect(result).toEqual([]);
+  });
+
+  it('should adapt items', async () => {
+    dao.items = [
+      { id: 'a1', name: 'Conta 1', type: 'CHECKING', balance: 100 },
+      { id: 'a2', name: 'Conta 2', type: 'SAVINGS', balance: 200 },
+    ];
+    const result = await handler.execute({ budgetId: 'b1', userId: 'u1' });
+    expect(result).toEqual([
+      { id: 'a1', name: 'Conta 1', type: 'CHECKING', balance: 100 },
+      { id: 'a2', name: 'Conta 2', type: 'SAVINGS', balance: 200 },
+    ]);
+  });
+});

--- a/src/application/queries/budget/list-accounts/ListAccountsQueryHandler.ts
+++ b/src/application/queries/budget/list-accounts/ListAccountsQueryHandler.ts
@@ -1,0 +1,52 @@
+/*
+- [ ] DAO interface created
+- [ ] DAO implemented with auth check + listing
+- [ ] Handler validates input and adapts output
+- [ ] Specs passing (DAO + Handler)
+- [ ] docs/query-view-planning.md updated row
+- [ ] No other files changed
+- [ ] Route NOT registered
+*/
+
+import { IQueryHandler } from '../../shared/IQueryHandler';
+import {
+  IListAccountsDao,
+  ListAccountsItem,
+} from '@application/contracts/daos/account/IListAccountsDao';
+
+export interface ListAccountsQuery {
+  budgetId: string;
+  userId: string;
+}
+
+export type ListAccountsQueryResult = ListAccountsItem[];
+
+export class ListAccountsQueryHandler
+  implements IQueryHandler<ListAccountsQuery, ListAccountsQueryResult>
+{
+  constructor(private readonly listAccountsDao: IListAccountsDao) {}
+
+  async execute(query: ListAccountsQuery): Promise<ListAccountsQueryResult> {
+    const { budgetId, userId } = query;
+
+    if (!budgetId || !userId) {
+      throw new Error('INVALID_INPUT');
+    }
+
+    const items = await this.listAccountsDao.findByBudgetForUser(
+      budgetId,
+      userId,
+    );
+
+    if (items === null) {
+      throw new Error('NOT_FOUND');
+    }
+
+    return items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      type: item.type,
+      balance: item.balance,
+    }));
+  }
+}

--- a/src/infrastructure/database/pg/daos/account/list-accounts/ListAccountsDao.spec.ts
+++ b/src/infrastructure/database/pg/daos/account/list-accounts/ListAccountsDao.spec.ts
@@ -1,0 +1,60 @@
+import { IPostgresConnectionAdapter } from '@infrastructure/adapters/IPostgresConnectionAdapter';
+import { ListAccountsDao } from './ListAccountsDao';
+
+describe('ListAccountsDao', () => {
+  let dao: ListAccountsDao;
+  let mockConnection: jest.Mocked<IPostgresConnectionAdapter>;
+
+  beforeEach(() => {
+    const mockClient = {
+      query: jest.fn(),
+      release: jest.fn(),
+    };
+
+    mockConnection = {
+      query: jest.fn(),
+      transaction: jest.fn(),
+      getClient: jest.fn().mockResolvedValue(mockClient),
+    } as unknown as jest.Mocked<IPostgresConnectionAdapter>;
+
+    dao = new ListAccountsDao(mockConnection);
+  });
+
+  it('should return null when user not authorized', async () => {
+    mockConnection.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+    expect(result).toBeNull();
+    expect(mockConnection.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return empty array when no accounts', async () => {
+    mockConnection.query
+      .mockResolvedValueOnce({ rows: [{ exists: '1' }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+    expect(result).toEqual([]);
+    expect(mockConnection.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('should map rows to ListAccountsItem', async () => {
+    mockConnection.query
+      .mockResolvedValueOnce({ rows: [{ exists: '1' }], rowCount: 1 })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'a1',
+            name: 'Conta',
+            type: 'CHECKING',
+            balance: '1000',
+          },
+        ],
+        rowCount: 1,
+      });
+
+    const result = await dao.findByBudgetForUser('b1', 'u1');
+    expect(result).toEqual([
+      { id: 'a1', name: 'Conta', type: 'CHECKING', balance: 1000 },
+    ]);
+  });
+});

--- a/src/infrastructure/database/pg/daos/account/list-accounts/ListAccountsDao.ts
+++ b/src/infrastructure/database/pg/daos/account/list-accounts/ListAccountsDao.ts
@@ -1,0 +1,39 @@
+import {
+  IListAccountsDao,
+  ListAccountsItem,
+} from '@application/contracts/daos/account/IListAccountsDao';
+import { IPostgresConnectionAdapter } from '../../../../../adapters/IPostgresConnectionAdapter';
+
+export class ListAccountsDao implements IListAccountsDao {
+  constructor(private readonly connection: IPostgresConnectionAdapter) {}
+
+  async findByBudgetForUser(
+    budgetId: string,
+    userId: string,
+  ): Promise<ListAccountsItem[] | null> {
+    const auth = await this.connection.query(
+      `SELECT 1 FROM budgets WHERE id = $1 AND (owner_id = $2 OR $2 = ANY(participant_ids))`,
+      [budgetId, userId],
+    );
+
+    if (!auth || auth.rowCount === 0) {
+      return null;
+    }
+
+    const result = await this.connection.query<
+      ListAccountsItem & { balance: string }
+    >(
+      `SELECT id, name, type, balance FROM accounts WHERE budget_id = $1 AND is_deleted = false ORDER BY name ASC`,
+      [budgetId],
+    );
+
+    return (
+      result?.rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        type: row.type,
+        balance: Number(row.balance),
+      })) || []
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add DAO contract and Postgres implementation for listing accounts with auth check
- implement ListAccountsQueryHandler with input validation and mapping
- document ListAccountsQueryHandler as implemented

## Testing
- `npm run lint`
- `npm test src/application/queries/budget/list-accounts/ListAccountsQueryHandler.spec.ts src/infrastructure/database/pg/daos/account/list-accounts/ListAccountsDao.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a76a998d2c832387a75dc3e0dce6c8